### PR TITLE
참여자 목록을 보여주는 기능 추가

### DIFF
--- a/frontend/src/components/MoimDescription/MoimDescription.stories.tsx
+++ b/frontend/src/components/MoimDescription/MoimDescription.stories.tsx
@@ -12,7 +12,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    description: '볼 함 차보까?',
+    title: '볼 함 차보까?',
+    children: '내용',
   },
   render: (args) => <MoimDescription {...args} />,
 };

--- a/frontend/src/components/MoimDescription/MoimDescription.tsx
+++ b/frontend/src/components/MoimDescription/MoimDescription.tsx
@@ -1,20 +1,22 @@
+import { ReactNode } from 'react';
 import * as S from './MoimDescription.style';
 
 interface MoimDescriptionProps {
-  description: string;
+  title: string;
+  children: ReactNode;
 }
 
 export default function MoimDescription(props: MoimDescriptionProps) {
-  const { description } = props;
+  const { title, children } = props;
 
-  if (description === '') {
+  if (title === '') {
     return;
   }
 
   return (
     <div css={S.containerStyle}>
-      <h2 css={S.titleStyle}>상세설명</h2>
-      <p css={S.descriptionStyle}>{description}</p>
+      <h2 css={S.titleStyle}>{title}</h2>
+      <div css={S.descriptionStyle}>{children}</div>
     </div>
   );
 }

--- a/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
+++ b/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
@@ -43,7 +43,18 @@ export default function MoimDetailPage() {
         <MoimSummary moimInfo={moim} />
         <MoimInformation moimInfo={moim} />
 
-        {moim.description && <MoimDescription description={moim.description} />}
+        {moim.description && (
+          <MoimDescription title={'상세설명'}>
+            {moim.description}
+          </MoimDescription>
+        )}
+        {moim.participants && (
+          <MoimDescription title="참여자">
+            {moim.participants.map((nickName) => {
+              return <p key={nickName}>{nickName}</p>;
+            })}
+          </MoimDescription>
+        )}
 
         <LabeledInput
           title="참가자 이름"

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -8,7 +8,11 @@ export interface MoimInfo {
   maxPeople: number;
   currentPeople: number;
   authorNickname: string;
+  participants: string[];
   description?: string;
 }
 
-export type MoimInputInfo = Omit<MoimInfo, 'moimId' | 'currentPeople'>;
+export type MoimInputInfo = Omit<
+  MoimInfo,
+  'moimId' | 'currentPeople' | 'participants'
+>;


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

모임 상세 보기에서 참여자 목록을 보여주는 기능을 추가한다.

## 이슈 ID는 무엇인가요?

- #110 

## 설명

<img width="641" alt="image" src="https://github.com/user-attachments/assets/6620c860-59c1-4d7c-bd8c-404055368031">

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
