### PR TITLE
desktop 환경에서의 max width 적용 및 상수화

### DIFF
--- a/frontend/src/common/reset.style.ts
+++ b/frontend/src/common/reset.style.ts
@@ -1,3 +1,4 @@
+import { DISPLAY_MAX_WIDTH } from '@_constants/styles';
 import { css } from '@emotion/react';
 
 const reset = css`
@@ -109,6 +110,9 @@ const reset = css`
   }
 
   body {
+    position: relative;
+    max-width: ${DISPLAY_MAX_WIDTH};
+    margin: 0 auto;
     line-height: 1;
   }
 

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -1,0 +1,1 @@
+export const DISPLAY_MAX_WIDTH = '60rem';

--- a/frontend/src/layouts/FormLayout/FormBottomWrapper/FormBottomWrapper.style.ts
+++ b/frontend/src/layouts/FormLayout/FormBottomWrapper/FormBottomWrapper.style.ts
@@ -1,9 +1,12 @@
+import { DISPLAY_MAX_WIDTH } from '@_constants/styles';
 import { css } from '@emotion/react';
 
 // TODO: 바텀 버튼 UI에 대한 기획 논의 필요
 export const bottomFixedStyle = css`
   position: fixed;
   bottom: 26px;
+
   width: 100%;
+  max-width: ${DISPLAY_MAX_WIDTH};
   padding: 0 16px;
 `;

--- a/frontend/src/layouts/HomeLayout.tsx/HomeFixedButtonWrapper/HomeFixedButtonWrapper.style.ts
+++ b/frontend/src/layouts/HomeLayout.tsx/HomeFixedButtonWrapper/HomeFixedButtonWrapper.style.ts
@@ -1,7 +1,14 @@
+import { DISPLAY_MAX_WIDTH } from '@_constants/styles';
 import { css } from '@emotion/react';
 
 export const fixedWrapperStyle = css`
   position: fixed;
-  right: 22px;
   bottom: 26px;
+
+  display: flex;
+  justify-content: right;
+
+  width: 100%;
+  max-width: ${DISPLAY_MAX_WIDTH};
+  padding-right: 4rem;
 `;

--- a/frontend/src/layouts/InformationLayout/InformationBottomWrapper/InformationBottomWrapper.style.ts
+++ b/frontend/src/layouts/InformationLayout/InformationBottomWrapper/InformationBottomWrapper.style.ts
@@ -1,9 +1,12 @@
+import { DISPLAY_MAX_WIDTH } from '@_constants/styles';
 import { css } from '@emotion/react';
 
 // TODO: 바텀 버튼 UI에 대한 기획 논의 필요
 export const bottomFixedStyle = css`
   position: fixed;
   bottom: 26px;
+
   width: 100%;
+  max-width: ${DISPLAY_MAX_WIDTH};
   padding: 0 16px;
 `;


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

desktop 환경에서 UI가 양 옆으로 늘어나지 않도록 width의 최대값 적용

## 이슈 ID는 무엇인가요?

- close #117

## 설명

1. body의 max-width 600px 적용, position이 fixed인 엘리먼트도 body의 max-width와 동일하게 적용
2. 해당 max-width 상수화 (DISPLAY_MAX_WIDTH)

## 질문 혹은 공유 사항 (Optional)


<img width="568" alt="image" src="https://github.com/user-attachments/assets/040ba47b-6f44-411b-bb27-4852962a5002">
<img width="588" alt="image" src="https://github.com/user-attachments/assets/a5221945-5bbf-4471-8104-6296543ccd4d">
<img width="585" alt="image" src="https://github.com/user-attachments/assets/2f16c283-ca62-4c24-84f3-b2369e127fd8">
