### PR TITLE
로그인 페이지 정적 UI 구현

### DIFF
--- a/frontend/src/components/LoginForm/LoginForm.stories.tsx
+++ b/frontend/src/components/LoginForm/LoginForm.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import LoginForm from './LoginForm';
+
+const meta = {
+  title: 'components/LoginForm',
+  component: LoginForm,
+} satisfies Meta<typeof LoginForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <LoginForm />,
+};

--- a/frontend/src/components/LoginForm/LoginForm.style.ts
+++ b/frontend/src/components/LoginForm/LoginForm.style.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+export const formContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+`;
+
+export const inputContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;

--- a/frontend/src/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,17 @@
+import Button from '@_components/Button/Button';
+import LabeledInput from '@_components/Input/MoimInput';
+import * as S from './LoginForm.style';
+
+export default function LoginForm() {
+  return (
+    <form css={S.formContainerStyle}>
+      <div css={S.inputContainerStyle}>
+        <LabeledInput title="아이디" />
+        <LabeledInput title="비밀번호" />
+      </div>
+      <Button shape="bar" onClick={() => {}} disabled>
+        로그인
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -3,6 +3,7 @@ const ROUTES = {
   addMoim: '/add-moim',
   detail: '/moim/:moimId',
   participationComplete: '/moim/participation-complete',
+  login: '/login',
 };
 
 export default ROUTES;

--- a/frontend/src/layouts/LoginLayout/LoginFooter/LoginFooter.style.ts
+++ b/frontend/src/layouts/LoginLayout/LoginFooter/LoginFooter.style.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const footerStyle = css`
+  padding: 24px;
+  text-align: center;
+  background-color: #f0f0f0;
+`;

--- a/frontend/src/layouts/LoginLayout/LoginFooter/LoginFooter.tsx
+++ b/frontend/src/layouts/LoginLayout/LoginFooter/LoginFooter.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import * as S from './LoginFooter.style';
+
+export default function LoginFooter(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <div css={S.footerStyle}>{children}</div>;
+}

--- a/frontend/src/layouts/LoginLayout/LoginHeader/LoginHeader.style.ts
+++ b/frontend/src/layouts/LoginLayout/LoginHeader/LoginHeader.style.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const headerStyle = css`
+  padding: 24px;
+  text-align: center;
+  background-color: #f0f0f0;
+`;

--- a/frontend/src/layouts/LoginLayout/LoginHeader/LoginHeader.tsx
+++ b/frontend/src/layouts/LoginLayout/LoginHeader/LoginHeader.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import * as S from './LoginHeader.style';
+
+export default function LoginHeader(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <div css={S.headerStyle}>{children}</div>;
+}

--- a/frontend/src/layouts/LoginLayout/LoginLayout.style.ts
+++ b/frontend/src/layouts/LoginLayout/LoginLayout.style.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const layoutStyle = css`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;

--- a/frontend/src/layouts/LoginLayout/LoginLayout.tsx
+++ b/frontend/src/layouts/LoginLayout/LoginLayout.tsx
@@ -1,0 +1,17 @@
+import { PropsWithChildren } from 'react';
+import * as S from './LoginLayout.style';
+import LoginHeader from './LoginHeader/LoginHeader';
+import LoginMain from './LoginMain/LoginMain';
+import LoginFooter from './LoginFooter/LoginFooter';
+
+function LoginLayout(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <div css={S.layoutStyle}>{children}</div>;
+}
+
+LoginLayout.Header = LoginHeader;
+LoginLayout.Main = LoginMain;
+LoginLayout.Footer = LoginFooter;
+
+export default LoginLayout;

--- a/frontend/src/layouts/LoginLayout/LoginMain/LoginMain.style.ts
+++ b/frontend/src/layouts/LoginLayout/LoginMain/LoginMain.style.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+export const mainStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  width: 80%;
+  height: 100%;
+  margin: 0 auto;
+`;

--- a/frontend/src/layouts/LoginLayout/LoginMain/LoginMain.tsx
+++ b/frontend/src/layouts/LoginLayout/LoginMain/LoginMain.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import * as S from './LoginMain.style';
+
+export default function LoginMain(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <div css={S.mainStyle}>{children}</div>;
+}

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -1,0 +1,13 @@
+import LoginForm from '@_components/LoginForm/LoginForm';
+import LoginLayout from '@_layouts/LoginLayout/LoginLayout';
+
+export default function LoginPage() {
+  return (
+    <LoginLayout>
+      <LoginLayout.Header>로그인</LoginLayout.Header>
+      <LoginLayout.Main>
+        <LoginForm />
+      </LoginLayout.Main>
+    </LoginLayout>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import ROUTES from '@_constants/routes';
 import { createBrowserRouter } from 'react-router-dom';
 import MoimDetailPage from '@_pages/MoimDetailPage/MoimDetailPage';
 import ParticipationCompletePage from '@_pages/ParticipationCompletePage/ParticipationCompletePage';
+import LoginPage from '@_pages/LoginPage/LoginPage';
 
 const router = createBrowserRouter([
   {
@@ -21,6 +22,10 @@ const router = createBrowserRouter([
   {
     path: ROUTES.participationComplete,
     element: <ParticipationCompletePage />,
+  },
+  {
+    path: ROUTES.login,
+    element: <LoginPage />,
   },
 ]);
 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

로그인 페이지의 정적 UI 기능 구현

## 이슈 ID는 무엇인가요?

- close #137 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

#### 결과물 UI
<img width="538" alt="image" src="https://github.com/user-attachments/assets/ad5b136e-c0b2-4b47-9d09-a4c6ecb1ad0d">


디자인 시안이 러프하게 작성되어있기 때문에, 일단은 스타일링은 크게 신경쓰지 않았고, 기본 구조를 만드는 것에 집중했어요. 아래 내용은 구현 과정의 사고를 작성해봤어요. 코드 리뷰에 도움이 되길 바랍니다 😄


1. 레이아웃
    - CompleteLayout과 구조가 비슷해서 재사용할까 했지만, 우연의 일치로 같은 것이고 추후에 Complete이든 Login이든 어느 하나가 Layout이 바뀌게 되면 찢어져야 하기 때문에 재사용하지 않는다.
    - 소파, 치코, 수야가 함께 약속한 것: 지금 당장은 layout의 재사용을 고려하지 말고, 일단은 page 하나당 layout 하나 만들자. 추후에(level4?) 리팩토링을 하면서 layout을 합쳐야하는 것들을 합치자.
    - → 결론적으로 LoginLayout을 구현했다.
2. 컴포넌트
    - 기존의 LabeldInput과 Button을 재사용했다.
    - 그 각각의 컴포넌트를 사용하는 LoginForm 컴포넌트를 만들었다.
3. 라우팅 및 페이지
    - App 밑에서 router로 분기될 LoginPage를 만들고, 그 LoginPage 안에서 LoginLayout과 LoginForm을 사용했다.
    - 추후에 UI 관련 요구사항이 변경될 경우 해당 요구사항에 해당되는 변경만 특정 컴포넌트에서 대응하면 될 것이라 기대한다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->

