### PR TITLE
채팅 데이터 생성 및 모임마다의 전체 조회 기능 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -1,0 +1,29 @@
+package mouda.backend.chat.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.service.ChatService;
+import mouda.backend.member.domain.Member;
+
+@RestController
+@RequestMapping("/v1/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+	private final ChatService chatService;
+
+	@PostMapping
+	public ResponseEntity<Void> createChat(
+		@RequestBody ChatCreateRequest chatCreateRequest,
+		Member member
+	) {
+		chatService.createChat(chatCreateRequest, member);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -1,14 +1,19 @@
 package mouda.backend.chat.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.dto.response.ChatFindUnloadedResponse;
 import mouda.backend.chat.service.ChatService;
+import mouda.backend.common.RestResponse;
 import mouda.backend.member.domain.Member;
 
 @RestController
@@ -20,10 +25,20 @@ public class ChatController {
 
 	@PostMapping
 	public ResponseEntity<Void> createChat(
-		@RequestBody ChatCreateRequest chatCreateRequest,
+		@Valid @RequestBody ChatCreateRequest chatCreateRequest,
 		Member member
 	) {
 		chatService.createChat(chatCreateRequest, member);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping
+	public ResponseEntity<RestResponse<ChatFindUnloadedResponse>> findUnloadedChats(
+		@RequestParam Long recentChatId,
+		@RequestParam Long moimId,
+		Member member
+	) {
+		ChatFindUnloadedResponse unloadedChats = chatService.findUnloadedChats(recentChatId, moimId, member);
+		return ResponseEntity.ok(new RestResponse<>(unloadedChats));
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Chat.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chat.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mouda.backend.member.domain.Member;
@@ -33,4 +34,13 @@ public class Chat {
 	private LocalDate date;
 
 	private LocalTime time;
+
+	@Builder
+	public Chat(String content, Moim moim, Member member, LocalDate date, LocalTime time) {
+		this.content = content;
+		this.moim = moim;
+		this.member = member;
+		this.date = date;
+		this.time = time;
+	}
 }

--- a/backend/src/main/java/mouda/backend/chat/dto/request/ChatCreateRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/request/ChatCreateRequest.java
@@ -1,0 +1,25 @@
+package mouda.backend.chat.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import mouda.backend.chat.domain.Chat;
+import mouda.backend.member.domain.Member;
+import mouda.backend.moim.domain.Moim;
+
+public record ChatCreateRequest(
+	@NotNull Long moimId,
+	@NotBlank String content
+) {
+	public Chat toEntity(Moim moim, Member member) {
+		return Chat.builder()
+			.content(content)
+			.date(LocalDate.now())
+			.time(LocalTime.now())
+			.member(member)
+			.moim(moim)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/dto/request/ChatCreateRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/request/ChatCreateRequest.java
@@ -10,8 +10,11 @@ import mouda.backend.member.domain.Member;
 import mouda.backend.moim.domain.Moim;
 
 public record ChatCreateRequest(
-	@NotNull Long moimId,
-	@NotBlank String content
+	@NotNull
+	Long moimId,
+	
+	@NotBlank
+	String content
 ) {
 	public Chat toEntity(Moim moim, Member member) {
 		return Chat.builder()

--- a/backend/src/main/java/mouda/backend/chat/dto/response/ChatFindDetailResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/response/ChatFindDetailResponse.java
@@ -1,0 +1,28 @@
+package mouda.backend.chat.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.Builder;
+import mouda.backend.chat.domain.Chat;
+
+@Builder
+public record ChatFindDetailResponse(
+	long chatId,
+	String content,
+	long memberId,
+	String nickname,
+	LocalDate date,
+	LocalTime time
+) {
+	public static ChatFindDetailResponse toResponse(Chat chat) {
+		return ChatFindDetailResponse.builder()
+			.chatId(chat.getId())
+			.content(chat.getContent())
+			.memberId(chat.getMember().getId())
+			.nickname(chat.getMember().getNickname())
+			.date(chat.getDate())
+			.time(chat.getTime())
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/dto/response/ChatFindUnloadedResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/response/ChatFindUnloadedResponse.java
@@ -1,0 +1,9 @@
+package mouda.backend.chat.dto.response;
+
+import java.util.List;
+
+public record ChatFindUnloadedResponse(
+	long loginMemberId,
+	List<ChatFindDetailResponse> chats
+) {
+}

--- a/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
@@ -1,0 +1,12 @@
+package mouda.backend.chat.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ChatErrorMessage {
+	MOIM_NOT_FOUND("존재하지 않는 모임에 채팅할 수 없습니다.");
+
+	private final String message;
+}

--- a/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ChatErrorMessage {
-	MOIM_NOT_FOUND("존재하지 않는 모임에 채팅할 수 없습니다.");
+
+	MOIM_NOT_FOUND("존재하지 않는 모임에 채팅할 수 없습니다."),
+	;
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/chat/exception/ChatException.java
+++ b/backend/src/main/java/mouda/backend/chat/exception/ChatException.java
@@ -1,0 +1,12 @@
+package mouda.backend.chat.exception;
+
+import org.springframework.http.HttpStatus;
+
+import mouda.backend.exception.MoudaException;
+
+public class ChatException extends MoudaException {
+
+	public ChatException(HttpStatus httpStatus, ChatErrorMessage chatErrorMessage) {
+		super(httpStatus, chatErrorMessage.getMessage());
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
@@ -1,8 +1,15 @@
 package mouda.backend.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import mouda.backend.chat.domain.Chat;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+	@Query("SELECT c FROM Chat c WHERE c.moim.id = :moimId AND c.id > :chatId")
+	List<Chat> findAllUnloadedChats(@Param("moimId") long moimId, @Param("chatId") long chatId);
 }

--- a/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
@@ -1,0 +1,8 @@
+package mouda.backend.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mouda.backend.chat.domain.Chat;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+}

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -35,6 +35,7 @@ public class ChatService {
 		List<ChatFindDetailResponse> chats = chatRepository.findAllUnloadedChats(moimId, recentChatId).stream()
 			.map(ChatFindDetailResponse::toResponse)
 			.toList();
+		
 		return new ChatFindUnloadedResponse(member.getId(), chats);
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -1,0 +1,26 @@
+package mouda.backend.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.chat.domain.Chat;
+import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.repository.ChatRepository;
+import mouda.backend.member.domain.Member;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.repository.MoimRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+	private final ChatRepository chatRepository;
+	private final MoimRepository moimRepository;
+
+	public void createChat(ChatCreateRequest chatCreateRequest, Member member) {
+		Moim moim = moimRepository.findById(chatCreateRequest.moimId())
+			.orElseThrow();
+		Chat chat = chatCreateRequest.toEntity(moim, member);
+		chatRepository.save(chat);
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -1,10 +1,17 @@
 package mouda.backend.chat.service;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import mouda.backend.chat.domain.Chat;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.dto.response.ChatFindDetailResponse;
+import mouda.backend.chat.dto.response.ChatFindUnloadedResponse;
+import mouda.backend.chat.exception.ChatErrorMessage;
+import mouda.backend.chat.exception.ChatException;
 import mouda.backend.chat.repository.ChatRepository;
 import mouda.backend.member.domain.Member;
 import mouda.backend.moim.domain.Moim;
@@ -19,8 +26,15 @@ public class ChatService {
 
 	public void createChat(ChatCreateRequest chatCreateRequest, Member member) {
 		Moim moim = moimRepository.findById(chatCreateRequest.moimId())
-			.orElseThrow();
+			.orElseThrow(() -> new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.MOIM_NOT_FOUND));
 		Chat chat = chatCreateRequest.toEntity(moim, member);
 		chatRepository.save(chat);
+	}
+
+	public ChatFindUnloadedResponse findUnloadedChats(long recentChatId, long moimId, Member member) {
+		List<ChatFindDetailResponse> chats = chatRepository.findAllUnloadedChats(moimId, recentChatId).stream()
+			.map(ChatFindDetailResponse::toResponse)
+			.toList();
+		return new ChatFindUnloadedResponse(member.getId(), chats);
 	}
 }

--- a/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
@@ -42,10 +42,10 @@ class ChatRepositoryTest {
 		memberRepository.save(member1);
 		memberRepository.save(member2);
 
-		Chat hogee = ChatFixture.getChatWithHogeeAtCoffeeMoim();
-		chatRepository.save(hogee);
-		Chat anna = ChatFixture.getChatWithAnnaAtCoffeeMoim();
+		Chat anna = ChatFixture.getChatWithMemberAtMoim(member1, moim);
 		chatRepository.save(anna);
+		Chat hogee = ChatFixture.getChatWithMemberAtMoim(member2, moim);
+		chatRepository.save(hogee);
 
 		List<Chat> chats = chatRepository.findAllUnloadedChats(1L, 1L);
 

--- a/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
@@ -2,8 +2,6 @@ package mouda.backend.chat.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import mouda.backend.chat.domain.Chat;
+import mouda.backend.fixture.ChatFixture;
+import mouda.backend.fixture.MemberFixture;
+import mouda.backend.fixture.MoimFixture;
 import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.moim.domain.Moim;
@@ -32,37 +33,19 @@ class ChatRepositoryTest {
 	@DisplayName("모임 아이디가 동일하고 채팅 아이디가 더 큰 채팅 리스트가 조회된다.")
 	@Test
 	void test() {
-		Moim moim = Moim.builder()
-			.place("asdf")
-			.maxPeople(1)
-			.description("123")
-			.time(LocalTime.now())
-			.date(LocalDate.now())
-			.title("sdfsdfsd")
-			.build();
+		Moim moim = MoimFixture.getCoffeeMoim();
 		moimRepository.save(moim);
 
-		Member member = Member.builder()
-			.nickname("hogee")
-			.build();
-		memberRepository.save(member);
+		Member member1 = MemberFixture.getAnna();
+		Member member2 = MemberFixture.getHogee();
 
-		Chat chat1 = Chat.builder()
-			.moim(moim)
-			.member(member)
-			.content("콘텐트")
-			.date(LocalDate.now())
-			.time(LocalTime.now())
-			.build();
-		Chat chat2 = Chat.builder()
-			.moim(moim)
-			.member(member)
-			.content("콘텐트")
-			.date(LocalDate.now())
-			.time(LocalTime.now())
-			.build();
-		chatRepository.save(chat1);
-		chatRepository.save(chat2);
+		memberRepository.save(member1);
+		memberRepository.save(member2);
+
+		Chat hogee = ChatFixture.getChatWithHogeeAtCoffeeMoim();
+		chatRepository.save(hogee);
+		Chat anna = ChatFixture.getChatWithAnnaAtCoffeeMoim();
+		chatRepository.save(anna);
 
 		List<Chat> chats = chatRepository.findAllUnloadedChats(1L, 1L);
 

--- a/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
@@ -1,0 +1,71 @@
+package mouda.backend.chat.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import mouda.backend.chat.domain.Chat;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.repository.MoimRepository;
+
+@DataJpaTest
+class ChatRepositoryTest {
+
+	@Autowired
+	private ChatRepository chatRepository;
+
+	@Autowired
+	private MoimRepository moimRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@DisplayName("모임 아이디가 동일하고 채팅 아이디가 더 큰 채팅 리스트가 조회된다.")
+	@Test
+	void test() {
+		Moim moim = Moim.builder()
+			.place("asdf")
+			.maxPeople(1)
+			.description("123")
+			.time(LocalTime.now())
+			.date(LocalDate.now())
+			.title("sdfsdfsd")
+			.build();
+		moimRepository.save(moim);
+
+		Member member = Member.builder()
+			.nickname("hogee")
+			.build();
+		memberRepository.save(member);
+
+		Chat chat1 = Chat.builder()
+			.moim(moim)
+			.member(member)
+			.content("콘텐트")
+			.date(LocalDate.now())
+			.time(LocalTime.now())
+			.build();
+		Chat chat2 = Chat.builder()
+			.moim(moim)
+			.member(member)
+			.content("콘텐트")
+			.date(LocalDate.now())
+			.time(LocalTime.now())
+			.build();
+		chatRepository.save(chat1);
+		chatRepository.save(chat2);
+
+		List<Chat> chats = chatRepository.findAllUnloadedChats(1L, 1L);
+
+		assertThat(chats).hasSize(1);
+	}
+}

--- a/backend/src/test/java/mouda/backend/fixture/ChatFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/ChatFixture.java
@@ -27,6 +27,16 @@ public class ChatFixture {
 			.build();
 	}
 
+	public static Chat getChatWithHogeeAtCoffeeMoim() {
+		return Chat.builder()
+			.time(LocalTime.now())
+			.date(LocalDate.now())
+			.content("반갑읍니다")
+			.member(MemberFixture.getHogee())
+			.moim(MoimFixture.getCoffeeMoim())
+			.build();
+	}
+
 	public static Chat getChatWithTebahAtSoccerMoim() {
 		return Chat.builder()
 			.time(LocalTime.now())

--- a/backend/src/test/java/mouda/backend/fixture/ChatFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/ChatFixture.java
@@ -4,46 +4,18 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import mouda.backend.chat.domain.Chat;
+import mouda.backend.member.domain.Member;
+import mouda.backend.moim.domain.Moim;
 
 public class ChatFixture {
 
-	public static Chat getChatWithHogeeAtBasketballMoim() {
+	public static Chat getChatWithMemberAtMoim(Member member, Moim moim) {
 		return Chat.builder()
 			.time(LocalTime.now())
 			.date(LocalDate.now())
-			.content("ㅎㅇㅎㅇ")
-			.member(MemberFixture.getHogee())
-			.moim(MoimFixture.getBasketballMoim())
-			.build();
-	}
-
-	public static Chat getChatWithAnnaAtCoffeeMoim() {
-		return Chat.builder()
-			.time(LocalTime.now())
-			.date(LocalDate.now())
-			.content("반갑읍니다")
-			.member(MemberFixture.getAnna())
-			.moim(MoimFixture.getCoffeeMoim())
-			.build();
-	}
-
-	public static Chat getChatWithHogeeAtCoffeeMoim() {
-		return Chat.builder()
-			.time(LocalTime.now())
-			.date(LocalDate.now())
-			.content("반갑읍니다")
-			.member(MemberFixture.getHogee())
-			.moim(MoimFixture.getCoffeeMoim())
-			.build();
-	}
-
-	public static Chat getChatWithTebahAtSoccerMoim() {
-		return Chat.builder()
-			.time(LocalTime.now())
-			.date(LocalDate.now())
-			.content("ㅎㅇㅎㅇ")
-			.member(MemberFixture.getTebah())
-			.moim(MoimFixture.getSoccerMoim())
+			.content("안녕하쎄요")
+			.member(member)
+			.moim(moim)
 			.build();
 	}
 }

--- a/backend/src/test/java/mouda/backend/fixture/MoimFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/MoimFixture.java
@@ -36,7 +36,7 @@ public class MoimFixture {
 			.date(LocalDate.now().plusDays(1))
 			.place("안나 집")
 			.description("커피 머신 들고와라")
-			.maxPeople(100)
+			.maxPeople(60)
 			.build();
 	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

채팅 데이터 생성 및 모임마다의 전체 조회 기능을 구현하였습니다.

## 이슈 ID는 무엇인가요?

- #147 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

우선 데이터베이스에 INSERT, SELECT 하는 방식으로 구현하였어요.
채팅을 조회할 때는 ""아직 조회되지 않은 채팅""을 필터링해서 목록을 클라이언트에게 보내줍니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
