### PR TITLE
모임 상태 변경 기능 구현 

### DIFF
--- a/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
+++ b/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
@@ -1,6 +1,7 @@
 package mouda.backend.chamyo.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,8 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import mouda.backend.chamyo.dto.response.ChamyoFindAllResponses;
+import mouda.backend.chamyo.dto.request.ChamyoCancelRequest;
 import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
+import mouda.backend.chamyo.dto.response.ChamyoFindAllResponses;
 import mouda.backend.chamyo.dto.response.MoimRoleFindResponse;
 import mouda.backend.chamyo.service.ChamyoService;
 import mouda.backend.common.RestResponse;
@@ -47,6 +49,14 @@ public class ChamyoController implements ChamyoSwagger {
 	@PostMapping
 	public ResponseEntity<Void> chamyoMoim(@Valid @RequestBody MoimChamyoRequest request, @LoginMember Member member) {
 		chamyoService.chamyoMoim(request, member);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@DeleteMapping
+	public ResponseEntity<Void> cancelChamyo(ChamyoCancelRequest request, Member member) {
+		chamyoService.cancelChamyo(request, member);
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
+++ b/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
@@ -55,7 +55,7 @@ public class ChamyoController implements ChamyoSwagger {
 
 	@Override
 	@DeleteMapping
-	public ResponseEntity<Void> cancelChamyo(ChamyoCancelRequest request, Member member) {
+	public ResponseEntity<Void> cancelChamyo(@Valid @RequestBody ChamyoCancelRequest request, Member member) {
 		chamyoService.cancelChamyo(request, member);
 
 		return ResponseEntity.ok().build();

--- a/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
+++ b/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoController.java
@@ -26,7 +26,7 @@ public class ChamyoController implements ChamyoSwagger {
 	private final ChamyoService chamyoService;
 
 	@Override
-	@GetMapping("/me")
+	@GetMapping("/mine")
 	public ResponseEntity<RestResponse<MoimRoleFindResponse>> findMoimRoleByMember(
 		@RequestParam Long moimId, @LoginMember Member member
 	) {

--- a/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoSwagger.java
+++ b/backend/src/main/java/mouda/backend/chamyo/controller/ChamyoSwagger.java
@@ -8,8 +8,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import mouda.backend.chamyo.dto.response.ChamyoFindAllResponses;
+import mouda.backend.chamyo.dto.request.ChamyoCancelRequest;
 import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
+import mouda.backend.chamyo.dto.response.ChamyoFindAllResponses;
 import mouda.backend.chamyo.dto.response.MoimRoleFindResponse;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
@@ -35,4 +36,10 @@ public interface ChamyoSwagger {
 		@ApiResponse(responseCode = "200", description = "모임 참여 성공")
 	})
 	ResponseEntity<Void> chamyoMoim(@Valid @RequestBody MoimChamyoRequest request, @LoginMember Member member);
+
+	@Operation(summary = "모임 참여 취소", description = "모임 참여를 취소합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모임 참여 취소 성공")
+	})
+	ResponseEntity<Void> cancelChamyo(@Valid @RequestBody ChamyoCancelRequest request, @LoginMember Member member);
 }

--- a/backend/src/main/java/mouda/backend/chamyo/dto/request/ChamyoCancelRequest.java
+++ b/backend/src/main/java/mouda/backend/chamyo/dto/request/ChamyoCancelRequest.java
@@ -1,0 +1,10 @@
+package mouda.backend.chamyo.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ChamyoCancelRequest(
+	@NotNull @Positive
+	Long moimId
+) {
+}

--- a/backend/src/main/java/mouda/backend/chamyo/exception/ChamyoErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/chamyo/exception/ChamyoErrorMessage.java
@@ -7,11 +7,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ChamyoErrorMessage {
 
-	MOIM_NOT_FOUND("참여하려는 모임이 존재하지 않습니다."),
-	MOIM_ALREADY_JOINED("이미 참여한 모임입니다."),
-	MOIM_FULL("최대 인원 수를 초과했습니다."),
-	MOIMING_CANCLED("취소된 모임입니다."),
-	MOIMING_COMPLETE("모집이 완료된 모임입니다.");
+	MOIM_NOT_FOUND("참여하려는 모임이 존재하지 않아요!"),
+	MOIM_ALREADY_JOINED("이미 참여했어요!"),
+	MOIM_FULL("모임이 꽉 찼어요!"),
+	MOIMING_CANCLED("모임이 취소됐어요!"),
+	MOIMING_COMPLETE("모집이 완료됐어요!"),
+	MOIM_NOT_JOINED("아직 참여하지 않았어요!"),
+	CANNOT_CANCEL_CHAMYO("취소할 수 없어요!");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/chamyo/repository/ChamyoRepository.java
+++ b/backend/src/main/java/mouda/backend/chamyo/repository/ChamyoRepository.java
@@ -20,4 +20,6 @@ public interface ChamyoRepository extends JpaRepository<Chamyo, Long> {
 	boolean existsByMoimAndMember(Moim moim, Member member);
 
 	void deleteAllByMoimId(Long moimId);
+
+	void deleteByMoimAndMember(Moim moim, Member member);
 }

--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -93,7 +93,7 @@ public class ChamyoService {
 
 	private void validateCanCancelChamyo(Moim moim, Member member) {
 		MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
-			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_JOINED))
+			.orElseThrow(() -> new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_JOINED))
 			.getMoimRole();
 
 		if (moimRole != MoimRole.MOIMEE) {

--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -10,9 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.chamyo.domain.Chamyo;
 import mouda.backend.chamyo.domain.MoimRole;
+import mouda.backend.chamyo.dto.request.ChamyoCancelRequest;
+import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
 import mouda.backend.chamyo.dto.response.ChamyoFindAllResponse;
 import mouda.backend.chamyo.dto.response.ChamyoFindAllResponses;
-import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
 import mouda.backend.chamyo.dto.response.MoimRoleFindResponse;
 import mouda.backend.chamyo.exception.ChamyoErrorMessage;
 import mouda.backend.chamyo.exception.ChamyoException;
@@ -79,6 +80,24 @@ public class ChamyoService {
 		}
 		if (chamyoRepository.existsByMoimAndMember(moim, member)) {
 			throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_ALREADY_JOINED);
+		}
+	}
+
+	public void cancelChamyo(ChamyoCancelRequest request, Member member) {
+		Moim moim = moimRepository.findById(request.moimId())
+			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_FOUND));
+		validateCanCancelChamyo(moim, member);
+
+		chamyoRepository.deleteByMoimAndMember(moim, member);
+	}
+
+	private void validateCanCancelChamyo(Moim moim, Member member) {
+		MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
+			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_JOINED))
+			.getMoimRole();
+
+		if (moimRole != MoimRole.MOIMEE) {
+			throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.CANNOT_CANCEL_CHAMYO);
 		}
 	}
 }

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
@@ -18,6 +18,7 @@ import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.member.domain.Member;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.dto.request.MoimCreateRequest;
+import mouda.backend.moim.dto.request.MoimEditRequest;
 import mouda.backend.moim.dto.request.MoimJoinRequest;
 import mouda.backend.moim.dto.response.MoimDetailsFindResponse;
 import mouda.backend.moim.dto.response.MoimFindAllResponses;
@@ -94,6 +95,14 @@ public class MoimController implements MoimSwagger {
 	@PatchMapping("/{moimId}/reopen")
 	public ResponseEntity<Void> reopenMoim(@PathVariable Long moimId, @LoginMember Member member) {
 		moimService.reopenMoim(moimId, member);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@PatchMapping
+	public ResponseEntity<Void> editMoim(@Valid @RequestBody MoimEditRequest request, @LoginMember Member member) {
+		moimService.editMoim(request, member);
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
@@ -83,6 +83,14 @@ public class MoimController implements MoimSwagger {
 	}
 
 	@Override
+	@PatchMapping("/cancel/{moimId}")
+	public ResponseEntity<Void> cancelMoim(@PathVariable Long moimId, @LoginMember Member member) {
+		moimService.cancelMoim(moimId, member);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
 	@PostMapping("/{moimId}")
 	public ResponseEntity<Void> createComment(
 		@LoginMember Member member,

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
@@ -75,7 +75,7 @@ public class MoimController implements MoimSwagger {
 	}
 
 	@Override
-	@PatchMapping("/{moimId}")
+	@PatchMapping("/{moimId}/complete")
 	public ResponseEntity<Void> completeMoim(@PathVariable Long moimId, @LoginMember Member member) {
 		moimService.completeMoim(moimId, member);
 

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
@@ -83,9 +83,17 @@ public class MoimController implements MoimSwagger {
 	}
 
 	@Override
-	@PatchMapping("/cancel/{moimId}")
+	@PatchMapping("/{moimId}/cancel")
 	public ResponseEntity<Void> cancelMoim(@PathVariable Long moimId, @LoginMember Member member) {
 		moimService.cancelMoim(moimId, member);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@PatchMapping("/{moimId}/reopen")
+	public ResponseEntity<Void> reopenMoim(@PathVariable Long moimId, @LoginMember Member member) {
+		moimService.reopenMoim(moimId, member);
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimController.java
@@ -3,6 +3,7 @@ package mouda.backend.moim.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,6 +70,14 @@ public class MoimController implements MoimSwagger {
 	@DeleteMapping("/{moimId}")
 	public ResponseEntity<Void> deleteMoim(@PathVariable Long moimId, @LoginMember Member member) {
 		moimService.deleteMoim(moimId, member);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@PatchMapping("/{moimId}")
+	public ResponseEntity<Void> completeMoim(@PathVariable Long moimId, @LoginMember Member member) {
+		moimService.completeMoim(moimId, member);
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
@@ -61,6 +61,12 @@ public interface MoimSwagger {
 	})
 	ResponseEntity<Void> cancelMoim(@PathVariable Long moimId, @LoginMember Member member);
 
+	@Operation(summary = "모집 재개", description = "방장이 모집을 재개합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모집 재개 성공!")
+	})
+	ResponseEntity<Void> reopenMoim(@PathVariable Long moimId, @LoginMember Member member);
+
 	@Operation(summary = "댓글 작성", description = "해당하는 id의 모임에 댓글을 생성한다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "댓글 생성 성공!")

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
@@ -55,6 +55,12 @@ public interface MoimSwagger {
 	})
 	ResponseEntity<Void> completeMoim(@PathVariable Long moimId, @LoginMember Member member);
 
+	@Operation(summary = "모임 취소", description = "방장이 모임을 취소합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모임 취소 성공!")
+	})
+	ResponseEntity<Void> cancelMoim(@PathVariable Long moimId, @LoginMember Member member);
+
 	@Operation(summary = "댓글 작성", description = "해당하는 id의 모임에 댓글을 생성한다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "댓글 생성 성공!")

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
@@ -7,11 +7,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import mouda.backend.comment.dto.request.CommentCreateRequest;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.member.domain.Member;
 import mouda.backend.moim.dto.request.MoimCreateRequest;
+import mouda.backend.moim.dto.request.MoimEditRequest;
 import mouda.backend.moim.dto.request.MoimJoinRequest;
 import mouda.backend.moim.dto.response.MoimDetailsFindResponse;
 import mouda.backend.moim.dto.response.MoimFindAllResponses;
@@ -66,6 +68,12 @@ public interface MoimSwagger {
 		@ApiResponse(responseCode = "200", description = "모집 재개 성공!")
 	})
 	ResponseEntity<Void> reopenMoim(@PathVariable Long moimId, @LoginMember Member member);
+
+	@Operation(summary = "모임 수정", description = "해당하는 id의 모임을 수정한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모임 수정 성공!")
+	})
+	ResponseEntity<Void> editMoim(@Valid @RequestBody MoimEditRequest request, @LoginMember Member member);
 
 	@Operation(summary = "댓글 작성", description = "해당하는 id의 모임에 댓글을 생성한다.")
 	@ApiResponses({

--- a/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
+++ b/backend/src/main/java/mouda/backend/moim/controller/MoimSwagger.java
@@ -49,6 +49,12 @@ public interface MoimSwagger {
 	})
 	ResponseEntity<Void> deleteMoim(@PathVariable Long moimId, @LoginMember Member member);
 
+	@Operation(summary = "모집 완료", description = "방장이 모집을 완료합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "모집 완료 성공!")
+	})
+	ResponseEntity<Void> completeMoim(@PathVariable Long moimId, @LoginMember Member member);
+
 	@Operation(summary = "댓글 작성", description = "해당하는 id의 모임에 댓글을 생성한다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "댓글 생성 성공!")

--- a/backend/src/main/java/mouda/backend/moim/domain/Moim.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Moim.java
@@ -3,6 +3,7 @@ package mouda.backend.moim.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
 
@@ -139,5 +140,40 @@ public class Moim {
 		if (currentPeople > maxPeople) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MAX_PEOPLE);
 		}
+	}
+
+	public void update(String title, LocalDate date, LocalTime time, String place, int maxPeople,
+		String description) {
+		if (!Objects.equals(this.title, title)) {
+			validateTitle(title);
+			this.title = title;
+		}
+
+		if (!Objects.equals(this.date, date)) {
+			validateDate(date);
+			this.date = date;
+		}
+
+		if (!Objects.equals(this.time, time)) {
+			validateTime(time);
+			this.time = time;
+		}
+
+		if (!Objects.equals(this.place, place)) {
+			validatePlace(place);
+			this.place = place;
+		}
+
+		if (!Objects.equals(this.maxPeople, maxPeople)) {
+			validateMaxPeople(maxPeople);
+			this.maxPeople = maxPeople;
+		}
+
+		if (!Objects.equals(this.description, description)) {
+			validateDescription(description);
+			this.description = description;
+		}
+
+		validateMoimIsFuture(this.date, this.time);
 	}
 }

--- a/backend/src/main/java/mouda/backend/moim/dto/request/MoimEditRequest.java
+++ b/backend/src/main/java/mouda/backend/moim/dto/request/MoimEditRequest.java
@@ -1,0 +1,31 @@
+package mouda.backend.moim.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record MoimEditRequest(
+	@NotNull @Positive
+	Long moimId,
+
+	@NotBlank
+	String title,
+
+	@NotNull
+	LocalDate date,
+
+	@NotNull
+	LocalTime time,
+
+	@NotBlank
+	String place,
+
+	@NotNull
+	Integer maxPeople,
+
+	String description
+) {
+}

--- a/backend/src/main/java/mouda/backend/moim/dto/response/MoimDetailsFindResponse.java
+++ b/backend/src/main/java/mouda/backend/moim/dto/response/MoimDetailsFindResponse.java
@@ -18,21 +18,20 @@ public record MoimDetailsFindResponse(
 	int maxPeople,
 	String authorNickname,
 	String description,
-	List<String> participants,
+	String status,
 	List<CommentResponse> comments
 ) {
 
-	public static MoimDetailsFindResponse toResponse(Moim moim, List<String> participants,
-		List<CommentResponse> comments) {
+	public static MoimDetailsFindResponse toResponse(Moim moim, int currentPeople, List<CommentResponse> comments) {
 		return MoimDetailsFindResponse.builder()
 			.title(moim.getTitle())
 			.date(moim.getDate())
 			.time(moim.getTime())
 			.place(moim.getPlace())
-			.currentPeople(participants.size())
+			.currentPeople(currentPeople)
 			.maxPeople(moim.getMaxPeople())
 			.description(moim.getDescription())
-			.participants(participants)
+			.status(moim.getMoimStatus().name())
 			.comments(comments)
 			.build();
 	}

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -26,7 +26,8 @@ public enum MoimErrorMessage {
 	NOT_ALLOWED_TO_DELETE("방장만 삭제할 수 있어요."),
 	NOT_ALLOWED_TO_COMPLETE("방장만 완료할 수 있어요."),
 	MOIM_CANCELED("이미 취소된 모임이에요."),
-	ALREADY_COMPLETED("이미 모집 완료된 모임이에요.");
+	ALREADY_COMPLETED("이미 모집 완료된 모임이에요."),
+	NOT_ALLOWED_TO_CANCEL("방장만 취소할 수 있어요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -27,7 +27,9 @@ public enum MoimErrorMessage {
 	NOT_ALLOWED_TO_COMPLETE("방장만 완료할 수 있어요."),
 	MOIM_CANCELED("이미 취소된 모임이에요."),
 	ALREADY_COMPLETED("이미 모집 완료된 모임이에요."),
-	NOT_ALLOWED_TO_CANCEL("방장만 취소할 수 있어요.");
+	NOT_ALLOWED_TO_CANCEL("방장만 취소할 수 있어요."),
+	NOT_ALLOWED_TO_REOPEN("방장만 다시 열 수 있어요."),
+	MOIM_FULL_FOR_REOPEN("모임이 꽉 차서 다시 열 수 없어요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -30,7 +30,8 @@ public enum MoimErrorMessage {
 	NOT_ALLOWED_TO_CANCEL("방장만 취소할 수 있어요."),
 	NOT_ALLOWED_TO_REOPEN("방장만 다시 열 수 있어요."),
 	MOIM_FULL_FOR_REOPEN("모임이 꽉 차서 다시 열 수 없어요."),
-	ALREADY_MOIMING("이미 모집 중인 모임이에요.");
+	ALREADY_MOIMING("이미 모집 중인 모임이에요."),
+	NOT_ALLOWED_TO_EDIT("방장만 수정할 수 있어요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -29,7 +29,8 @@ public enum MoimErrorMessage {
 	ALREADY_COMPLETED("이미 모집 완료된 모임이에요."),
 	NOT_ALLOWED_TO_CANCEL("방장만 취소할 수 있어요."),
 	NOT_ALLOWED_TO_REOPEN("방장만 다시 열 수 있어요."),
-	MOIM_FULL_FOR_REOPEN("모임이 꽉 차서 다시 열 수 없어요.");
+	MOIM_FULL_FOR_REOPEN("모임이 꽉 차서 다시 열 수 없어요."),
+	ALREADY_MOIMING("이미 모집 중인 모임이에요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -23,7 +23,10 @@ public enum MoimErrorMessage {
 	DESCRIPTION_TOO_LONG("모임 설명을 조금 더 짧게 입력해주세요."),
 	MEMBER_NICKNAME_NOT_EXISTS("모임 참여자 닉네임을 입력해주세요."),
 	MEMBER_NICKNAME_TOO_LONG("모임 참여자 닉네임을 조금 더 짧게 입력해주세요."),
-	NOT_ALLOWED_TO_DELETE("방장만 삭제할 수 있어요.");
+	NOT_ALLOWED_TO_DELETE("방장만 삭제할 수 있어요."),
+	NOT_ALLOWED_TO_COMPLETE("방장만 완료할 수 있어요."),
+	MOIM_CANCELED("이미 취소된 모임이에요."),
+	ALREADY_COMPLETED("이미 모집 완료된 모임이에요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -189,6 +189,13 @@ public class MoimService {
 		if (currentPeople >= moim.getMaxPeople()) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_FULL_FOR_REOPEN);
 		}
+		MoimStatus moimStatus = moim.getMoimStatus();
+		if (moimStatus == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+		if (moimStatus == MoimStatus.MOIMING) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_MOIMING);
+		}
 	}
 
 	private void validateIsMoimerWithErrorMessage(Moim moim, Member member, MoimErrorMessage errorMessage) {

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -74,14 +74,10 @@ public class MoimService {
 		Moim moim = moimRepository.findById(id)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
 
-		List<String> participants = memberRepository.findAllByMoimId(id).stream()
-			.map(Member::getNickname)
-			.toList();
-
 		List<Comment> comments = commentRepository.findAllByMoimIdOrderByCreatedAt(id);
 		List<CommentResponse> commentResponses = toCommentResponse(comments);
 
-		return MoimDetailsFindResponse.toResponse(moim, participants, commentResponses);
+		return MoimDetailsFindResponse.toResponse(moim, chamyoRepository.countByMoim(moim), commentResponses);
 	}
 
 	private List<CommentResponse> toCommentResponse(List<Comment> comments) {

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -169,4 +169,24 @@ public class MoimService {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
 		}
 	}
+
+	public void cancelMoim(Long moimId, Member member) {
+		Moim moim = moimRepository.findById(moimId)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanCancelMoim(moim, member);
+
+		moimRepository.updateMoimStatusById(moimId, MoimStatus.CANCELED);
+	}
+
+	private void validateCanCancelMoim(Moim moim, Member member) {
+		MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND))
+			.getMoimRole();
+		if (moimRole != MoimRole.MOIMER) {
+			throw new MoimException(HttpStatus.FORBIDDEN, MoimErrorMessage.NOT_ALLOWED_TO_CANCEL);
+		}
+		if (moim.getMoimStatus() == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+	}
 }

--- a/backend/src/main/java/mouda/backend/zzim/controller/ZzimController.java
+++ b/backend/src/main/java/mouda/backend/zzim/controller/ZzimController.java
@@ -25,7 +25,7 @@ public class ZzimController implements ZzimSwagger {
 	private final ZzimService zzimService;
 
 	@Override
-	@GetMapping("/me")
+	@GetMapping("/mine")
 	public ResponseEntity<RestResponse<ZzimCheckResponse>> checkZzimByMoimAndMember(
 		@RequestParam Long moimId, @LoginMember Member member
 	) {

--- a/backend/src/test/java/mouda/backend/moim/MoimControllerTest.java
+++ b/backend/src/test/java/mouda/backend/moim/MoimControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
 
 import io.restassured.RestAssured;
 import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
@@ -25,6 +26,7 @@ import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.domain.MoimStatus;
 import mouda.backend.moim.dto.request.MoimCreateRequest;
+import mouda.backend.moim.dto.request.MoimEditRequest;
 import mouda.backend.moim.repository.MoimRepository;
 import mouda.backend.moim.service.MoimService;
 
@@ -70,10 +72,14 @@ public class MoimControllerTest {
 			Member tebah = memberRepository.findByNickname("테바").get();
 			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
-				.then().statusCode(200);
+				.when()
+				.patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then()
+				.statusCode(200);
 
 			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.COMPLETED);
 		}
@@ -88,10 +94,16 @@ public class MoimControllerTest {
 
 			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
-				.then().log().all().statusCode(403);
+				.when()
+				.patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then()
+				.log()
+				.all()
+				.statusCode(403);
 		}
 
 		@DisplayName("이미 모집이 완료된 경우 모집을 완료할 수 없다.")
@@ -103,10 +115,14 @@ public class MoimControllerTest {
 
 			moimService.completeMoim(moim.getId(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then()
+				.statusCode(400);
 		}
 
 		@DisplayName("취소된 모임에 대해서는 모집을 완료할 수 없다.")
@@ -118,10 +134,14 @@ public class MoimControllerTest {
 
 			moimService.cancelMoim(moim.getId(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then()
+				.statusCode(400);
 		}
 	}
 
@@ -141,10 +161,14 @@ public class MoimControllerTest {
 			Member tebah = memberRepository.findByNickname("테바").get();
 			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
-				.then().statusCode(200);
+				.when()
+				.patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then()
+				.statusCode(200);
 
 			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.CANCELED);
 		}
@@ -159,10 +183,16 @@ public class MoimControllerTest {
 
 			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
-				.then().log().all().statusCode(403);
+				.when()
+				.patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then()
+				.log()
+				.all()
+				.statusCode(403);
 		}
 
 		@DisplayName("이미 취소된 모임은 취소할 수 없다.")
@@ -174,10 +204,14 @@ public class MoimControllerTest {
 
 			moimService.cancelMoim(moim.getId(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then()
+				.statusCode(400);
 		}
 	}
 
@@ -199,10 +233,14 @@ public class MoimControllerTest {
 
 			moimService.completeMoim(moim.getId(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
-				.then().statusCode(200);
+				.when()
+				.patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then()
+				.statusCode(200);
 
 			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.MOIMING);
 		}
@@ -217,10 +255,16 @@ public class MoimControllerTest {
 
 			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
-				.then().log().all().statusCode(403);
+				.when()
+				.patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then()
+				.log()
+				.all()
+				.statusCode(403);
 		}
 
 		@DisplayName("인원이 가득 찬 모임은 재개할 수 없다.")
@@ -233,10 +277,14 @@ public class MoimControllerTest {
 
 			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), hogee);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then()
+				.statusCode(400);
 		}
 
 		@DisplayName("이미 모집 중인 모임은 재개할 수 없다.")
@@ -246,10 +294,14 @@ public class MoimControllerTest {
 			Member tebah = memberRepository.findByNickname("테바").get();
 			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then()
+				.statusCode(400);
 		}
 
 		@DisplayName("이미 취소된 모임은 재개할 수 없다.")
@@ -261,10 +313,140 @@ public class MoimControllerTest {
 
 			moimService.cancelMoim(moim.getId(), tebah);
 
-			RestAssured.given().log().all()
+			RestAssured.given()
+				.log()
+				.all()
 				.header("Authorization", "Bearer " + accessToken)
-				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
-				.then().statusCode(400);
+				.when()
+				.patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then()
+				.statusCode(400);
+		}
+	}
+
+	@Nested
+	@DisplayName("모임 수정 테스트")
+	class EditMoimTest {
+
+		@AfterEach
+		void tearDown() {
+			dbCleaner.cleanUp();
+		}
+
+		@DisplayName("방장이 아닌 참여자는 모임을 수정할 수 없다.")
+		@Test
+		void fail_whenMemberIsNotMoimer() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), hogee);
+
+			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), memberRepository.findByNickname("테바").get());
+			MoimEditRequest request = getMoimEditRequest(moim.getId(), "test", LocalDate.now().plusDays(1),
+				LocalTime.now(), "test", 10, "test");
+
+			RestAssured.given()
+				.log()
+				.all()
+				.header("Authorization", "Bearer " + accessToken)
+				.body(request)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.when()
+				.patch("/v1/moim")
+				.then()
+				.log()
+				.all()
+				.statusCode(403);
+		}
+
+		@DisplayName("완료된 모임은 수정할 수 없다.")
+		@Test
+		void fail_whenMoimCompleted() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.completeMoim(moim.getId(), tebah);
+			MoimEditRequest request = getMoimEditRequest(moim.getId(), "test", LocalDate.now().plusDays(1),
+				LocalTime.now(), "test", 10, "test");
+
+			RestAssured.given()
+				.log()
+				.all()
+				.header("Authorization", "Bearer " + accessToken)
+				.body(request)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.when()
+				.patch("/v1/moim")
+				.then()
+				.log()
+				.all()
+				.statusCode(400);
+		}
+
+		@DisplayName("취소된 모임은 수정할 수 없다.")
+		@Test
+		void fail_whenMoimCanceled() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.cancelMoim(moim.getId(), tebah);
+			MoimEditRequest request = getMoimEditRequest(moim.getId(), "test", LocalDate.now().plusDays(1),
+				LocalTime.now(), "test", 10, "test");
+
+			RestAssured.given()
+				.log()
+				.all()
+				.header("Authorization", "Bearer " + accessToken)
+				.body(request)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.when()
+				.patch("/v1/moim")
+				.then()
+				.log()
+				.all()
+				.statusCode(400);
+		}
+
+		@DisplayName("모임을 수정한다.")
+		@Test
+		void success() {
+			String newTitle = "newTitle";
+			LocalDate newDate = LocalDate.now().plusDays(7);
+			LocalTime newTime = LocalTime.now().minusHours(1);
+			String newPlace = "newPlace";
+			int newMaxPeople = 20;
+			String newDescription = "newDescription";
+
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			MoimEditRequest request = getMoimEditRequest(moim.getId(), newTitle, newDate, newTime, newPlace,
+				newMaxPeople, newDescription);
+
+			RestAssured.given()
+				.log()
+				.all()
+				.header("Authorization", "Bearer " + accessToken)
+				.body(request)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.when()
+				.patch("/v1/moim")
+				.then()
+				.log()
+				.all()
+				.statusCode(200);
+
+			Moim newMoim = moimRepository.findById(moim.getId()).get();
+			assertThat(newMoim.getTitle()).isEqualTo(newTitle);
+			assertThat(newMoim.getDate()).isEqualTo(newDate);
+			assertThat(newMoim.getTime().getHour()).isEqualTo(newTime.getHour());
+			assertThat(newMoim.getTime().getMinute()).isEqualTo(newTime.getMinute());
+			assertThat(newMoim.getTime().getSecond()).isEqualTo(newTime.getSecond());
+			assertThat(newMoim.getPlace()).isEqualTo(newPlace);
+			assertThat(newMoim.getMaxPeople()).isEqualTo(newMaxPeople);
+			assertThat(newMoim.getDescription()).isEqualTo(newDescription);
 		}
 	}
 
@@ -273,9 +455,11 @@ public class MoimControllerTest {
 	}
 
 	private MoimCreateRequest getMoimCreateRequest(int maxPeople) {
-		return new MoimCreateRequest(
-			"test", LocalDate.now().plusDays(1), LocalTime.now(),
-			"test", maxPeople, "test"
-		);
+		return new MoimCreateRequest("test", LocalDate.now().plusDays(1), LocalTime.now(), "test", maxPeople, "test");
+	}
+
+	private MoimEditRequest getMoimEditRequest(Long moimId, String title, LocalDate date, LocalTime time, String place,
+		int maxPeople, String description) {
+		return new MoimEditRequest(moimId, title, date, time, place, maxPeople, description);
 	}
 }

--- a/backend/src/test/java/mouda/backend/moim/MoimControllerTest.java
+++ b/backend/src/test/java/mouda/backend/moim/MoimControllerTest.java
@@ -1,0 +1,281 @@
+package mouda.backend.moim;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.restassured.RestAssured;
+import mouda.backend.chamyo.dto.request.MoimChamyoRequest;
+import mouda.backend.chamyo.service.ChamyoService;
+import mouda.backend.config.DatabaseCleaner;
+import mouda.backend.fixture.MemberFixture;
+import mouda.backend.fixture.TokenFixture;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.domain.MoimStatus;
+import mouda.backend.moim.dto.request.MoimCreateRequest;
+import mouda.backend.moim.repository.MoimRepository;
+import mouda.backend.moim.service.MoimService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MoimControllerTest {
+
+	@Autowired
+	private ChamyoService chamyoService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MoimRepository moimRepository;
+
+	@Autowired
+	private MoimService moimService;
+
+	@Autowired
+	private DatabaseCleaner dbCleaner;
+
+	@LocalServerPort
+	private int port;
+
+	@BeforeEach
+	void setUp() {
+		RestAssured.port = port;
+	}
+
+	@Nested
+	@DisplayName("모집 완료 테스트")
+	class CompleteMoimTest {
+
+		@AfterEach
+		void tearDown() {
+			dbCleaner.cleanUp();
+		}
+
+		@DisplayName("방장이 모집을 완료한다.")
+		@Test
+		void success() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then().statusCode(200);
+
+			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.COMPLETED);
+		}
+
+		@DisplayName("방장이 아닌 참여자는 모집을 완료할 수 없다.")
+		@Test
+		void fail_whenMemberIsNotMoimer() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), hogee);
+
+			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then().log().all().statusCode(403);
+		}
+
+		@DisplayName("이미 모집이 완료된 경우 모집을 완료할 수 없다.")
+		@Test
+		void fail_whenMoimIsAlreadyCompleted() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.completeMoim(moim.getId(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then().statusCode(400);
+		}
+
+		@DisplayName("취소된 모임에 대해서는 모집을 완료할 수 없다.")
+		@Test
+		void fail_whenMoimIsAlreadyCanceled() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.cancelMoim(moim.getId(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/complete", moim.getId())
+				.then().statusCode(400);
+		}
+	}
+
+	@Nested
+	@DisplayName("모임 취소 테스트")
+	class CancelMoimTest {
+
+		@BeforeEach
+		void setUp() {
+			dbCleaner.cleanUp();
+		}
+
+		@DisplayName("방장이 모임을 취소한다.")
+		@Test
+		void success() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then().statusCode(200);
+
+			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.CANCELED);
+		}
+
+		@DisplayName("방장이 아닌 참여자는 모임을 취소할 수 없다.")
+		@Test
+		void fail_whenMemberIsNotMoimer() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), hogee);
+
+			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then().log().all().statusCode(403);
+		}
+
+		@DisplayName("이미 취소된 모임은 취소할 수 없다.")
+		@Test
+		void fail_whenMoimIsAlreadyCanceled() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.cancelMoim(moim.getId(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/cancel", moim.getId())
+				.then().statusCode(400);
+		}
+	}
+
+	@Nested
+	@DisplayName("모임 재개 테스트")
+	class ReopenMoimTest {
+
+		@BeforeEach
+		void setUp() {
+			dbCleaner.cleanUp();
+		}
+
+		@DisplayName("방장이 모임을 재개한다.")
+		@Test
+		void success() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.completeMoim(moim.getId(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then().statusCode(200);
+
+			assertThat(moimRepository.findById(moim.getId()).get().getMoimStatus()).isEqualTo(MoimStatus.MOIMING);
+		}
+
+		@DisplayName("방장이 아닌 참여자는 모임을 재개할 수 없다.")
+		@Test
+		void fail_whenMemberIsNotMoimer() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), hogee);
+
+			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then().log().all().statusCode(403);
+		}
+
+		@DisplayName("인원이 가득 찬 모임은 재개할 수 없다.")
+		@Test
+		void fail_whenMoimIsFull() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(2), tebah);
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+
+			chamyoService.chamyoMoim(new MoimChamyoRequest(moim.getId()), hogee);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then().statusCode(400);
+		}
+
+		@DisplayName("이미 모집 중인 모임은 재개할 수 없다.")
+		@Test
+		void fail_whenAlreadyMoiming() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then().statusCode(400);
+		}
+
+		@DisplayName("이미 취소된 모임은 재개할 수 없다.")
+		@Test
+		void fail_whenMoimIsAlreadyCanceled() {
+			String accessToken = TokenFixture.getTokenWithNicknameTebah();
+			Member tebah = memberRepository.findByNickname("테바").get();
+			Moim moim = moimService.createMoim(getMoimCreateRequest(), tebah);
+
+			moimService.cancelMoim(moim.getId(), tebah);
+
+			RestAssured.given().log().all()
+				.header("Authorization", "Bearer " + accessToken)
+				.when().patch("/v1/moim/{moimId}/reopen", moim.getId())
+				.then().statusCode(400);
+		}
+	}
+
+	private MoimCreateRequest getMoimCreateRequest() {
+		return getMoimCreateRequest(10);
+	}
+
+	private MoimCreateRequest getMoimCreateRequest(int maxPeople) {
+		return new MoimCreateRequest(
+			"test", LocalDate.now().plusDays(1), LocalTime.now(),
+			"test", maxPeople, "test"
+		);
+	}
+}

--- a/backend/src/test/java/mouda/backend/moim/domain/MoimTest.java
+++ b/backend/src/test/java/mouda/backend/moim/domain/MoimTest.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import mouda.backend.fixture.MoimFixture;
@@ -19,7 +20,6 @@ class MoimTest {
 	private static final LocalTime TIME = LocalTime.now().plusHours(1);
 	private static final String PLACE = "서울시 동작구 강원대로 10길 5";
 	private static final int MAX_PEOPLE = 11;
-	private static final String AUTHOR_NICKNAME = "안나";
 	private static final String DESCRIPTION = "이번 주 금요일에 퇴근하고 축구하실 분 계신가요? 끝나고 치맥도 할 생각입니다.";
 
 	@DisplayName("모임 객체를 정상적으로 생성한다.")
@@ -94,7 +94,7 @@ class MoimTest {
 			.build());
 	}
 
-	@DisplayName("모임 시간이 현재보다 과거이면 모임 객체 생성에 실패한다.")
+	@DisplayName("날짜는 같고, 시간이 현재보다 과거이면 모임 객체 생성에 실패한다.")
 	@Test
 	void failToCreateMoimWhenTimeIsPast() {
 		assertThrows(MoimException.class, () -> Moim.builder()
@@ -185,5 +185,111 @@ class MoimTest {
 			.maxPeople(MAX_PEOPLE)
 			.description(longDescription)
 			.build());
+	}
+
+	@Nested
+	@DisplayName("모임 수정 테스트")
+	class UpdateMoimTest {
+
+		private Moim moim = Moim.builder()
+			.title(TITLE)
+			.date(DATE)
+			.time(TIME)
+			.place(PLACE)
+			.maxPeople(MAX_PEOPLE)
+			.description(DESCRIPTION)
+			.build();
+
+		@DisplayName("최대 길이를 초과하는 제목으로는 수정할 수 없다.")
+		@Test
+		void fail_whenTitleIsTooLong() {
+			String longTitle = "a".repeat(31);
+			assertThrows(MoimException.class, () -> moim.update(longTitle, DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("제목이 빈 문자열이면 수정할 수 없다.")
+		@Test
+		void fail_whenTitleDoesNotExists() {
+			assertThrows(MoimException.class, () -> moim.update("", DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("날짜가 null이면 수정할 수 없다.")
+		@Test
+		void fail_whenDateIsNull() {
+			assertThrows(MoimException.class, () -> moim.update(TITLE, null, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("시간이 null이면 수정할 수 없다.")
+		@Test
+		void fail_whenTimeIsNull() {
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, null, PLACE, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("모임 날짜가 현재보다 과거이면 수정할 수 없다.")
+		@Test
+		void fail_whenDateIsPast() {
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, LocalDate.now().minusDays(1), TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("날짜는 같고, 시간이 현재보다 과거이면 수정할 수 없다.")
+		@Test
+		void fail_whenTimeIsPast() {
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, LocalDate.now(), LocalTime.now().minusHours(1), PLACE, MAX_PEOPLE,
+					DESCRIPTION));
+		}
+
+		@DisplayName("장소가 빈 문자열이면 수정할 수 없다.")
+		@Test
+		void fail_whenPlaceIsBlank() {
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, "", MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("장소 길이가 제한을 초과하면 수정할 수 없다.")
+		@Test
+		void fail_whenPlaceIsTooLong() {
+			String longPlace = "a".repeat(101);
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, longPlace, MAX_PEOPLE, DESCRIPTION));
+		}
+
+		@DisplayName("모임 최대 인원이 1보다 작으면 수정할 수 없다.")
+		@Test
+		void fail_whenMaxPeopleIsTooSmall() {
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, 0, DESCRIPTION));
+		}
+
+		@DisplayName("모임 최대 인원이 제한을 초과하면 수정할 수 없다.")
+		@Test
+		void fail_whenMaxPeopleIsTooMany() {
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, 100, DESCRIPTION));
+		}
+
+		@DisplayName("설명의 길이가 길면 수정할 수 없다.")
+		@Test
+		void fail_whenDescriptionIsTooLong() {
+			String longDescription = "a".repeat(1001);
+			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, MAX_PEOPLE, longDescription));
+		}
+
+		@DisplayName("모임 객체를 수정한다.")
+		@Test
+		void updateMoim() {
+			String newTitle = "축구 모집합니다.";
+			LocalDate newDate = LocalDate.now().plusDays(2);
+			LocalTime newTime = LocalTime.now().plusHours(2);
+			String newPlace = "서울시 강남구 강남대로 10길 5";
+			int newMaxPeople = 10;
+			String newDescription = "축구하실 분 구합니다.";
+
+			moim.update(newTitle, newDate, newTime, newPlace, newMaxPeople, newDescription);
+
+			assertEquals(newTitle, moim.getTitle());
+			assertEquals(newDate, moim.getDate());
+			assertEquals(newTime, moim.getTime());
+			assertEquals(newPlace, moim.getPlace());
+			assertEquals(newMaxPeople, moim.getMaxPeople());
+			assertEquals(newDescription, moim.getDescription());
+		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/zzim/controller/ZzimControllerTest.java
+++ b/backend/src/test/java/mouda/backend/zzim/controller/ZzimControllerTest.java
@@ -24,8 +24,8 @@ import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.dto.request.MoimCreateRequest;
 import mouda.backend.moim.service.MoimService;
-import mouda.backend.zzim.dto.response.ZzimCheckResponse;
 import mouda.backend.zzim.dto.request.ZzimUpdateRequest;
+import mouda.backend.zzim.dto.response.ZzimCheckResponse;
 import mouda.backend.zzim.service.ZzimService;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -74,7 +74,7 @@ class ZzimControllerTest {
 			RestAssured.given()
 				.header("Authorization", "Bearer " + accessToken)
 				.param("moimId", moim.getId())
-				.when().get("/v1/zzim/me")
+				.when().get("/v1/zzim/mine")
 				.then().statusCode(200)
 				.body("data.isZzimed", is(true));
 		}
@@ -90,7 +90,7 @@ class ZzimControllerTest {
 			RestAssured.given()
 				.header("Authorization", "Bearer " + accessToken)
 				.param("moimId", moim.getId())
-				.when().get("/v1/zzim/me")
+				.when().get("/v1/zzim/mine")
 				.then().statusCode(200)
 				.body("data.isZzimed", is(false));
 		}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

모임 상태 변경및 참여 취소 기능 추가

## 이슈 ID는 무엇인가요?

- #173 

## 설명

- [x] 모임 수정 기능 추가
- [x] 방장이 모집을 완료, 취소하는 기능 추가
- [x] 방장이 아닌 참여자가 모임 참여를 취소하는 기능 추가 

## 질문 혹은 공유 사항 (Optional)

금요일에 기능을 합치는데 지장이 없도록 최대한 빠르게 구현하였습니다. 짧은 시간 안에 구현하려는 탓에 사소하게 놓치거나 빠진 부분이 있을 것 같아요. 

몇몇 부분은 전체 기능이 완료되고 한 번에 수정하는게 나은 것 같더라구요. 그래도 혹시 모르니 빠진 부분에 대해서는 의견 남겨주시면 땡큐!
