### PR TITLE
`@LoginMember`가 스웨거 파라미터에 포함되지 않도록 수정. 인증 정보 입력할 수 있도록 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
@@ -4,18 +4,13 @@ import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import mouda.backend.config.argumentresolver.LoginMember;
 
 @Configuration
-@SecurityScheme(
-	name = "Bearer Authorization",
-	type = SecuritySchemeType.HTTP,
-	bearerFormat = "JWT",
-	scheme = "bearer"
-)
 public class SwaggerConfig {
 
 	static {
@@ -24,6 +19,16 @@ public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
-		return new OpenAPI();
+		return new OpenAPI().addSecurityItem(
+				new SecurityRequirement().addList("Bearer Authorization"))
+			.components(new Components().addSecuritySchemes(
+				"Bearer Authorization", createAPIKeyScheme()
+			));
+	}
+
+	private SecurityScheme createAPIKeyScheme() {
+		return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+			.bearerFormat("JWT")
+			.scheme("bearer");
 	}
 }

--- a/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package mouda.backend.config;
+
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.OpenAPI;
+import mouda.backend.config.argumentresolver.LoginMember;
+
+@Configuration
+@SecurityScheme(
+	name = "Bearer Authorization",
+	type = SecuritySchemeType.HTTP,
+	bearerFormat = "JWT",
+	scheme = "bearer"
+)
+public class SwaggerConfig {
+
+	static {
+		SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginMember.class);
+	}
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI();
+	}
+}

--- a/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/mouda/backend/config/SwaggerConfig.java
@@ -22,11 +22,11 @@ public class SwaggerConfig {
 		return new OpenAPI().addSecurityItem(
 				new SecurityRequirement().addList("Bearer Authorization"))
 			.components(new Components().addSecuritySchemes(
-				"Bearer Authorization", createAPIKeyScheme()
+				"Bearer Authorization", createBearerTokenScheme()
 			));
 	}
 
-	private SecurityScheme createAPIKeyScheme() {
+	private SecurityScheme createBearerTokenScheme() {
 		return new SecurityScheme().type(SecurityScheme.Type.HTTP)
 			.bearerFormat("JWT")
 			.scheme("bearer");


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

1. 컨트롤러 파라미터에 `@LoginMember` 어노테이션을 붙여서 Header 로 토큰을 가져오도록 하고 있습니다. 스웨거에서 이 파라미터를 필수로 넣어야 하는 불편함이 있기 때문에 스웨거 설정 파일을 생성해서 해당 어노테이션이 추가된 파라미터는 제외하도록 설정하였습니다. 

2. 스웨거에서 로그인 후 헤더에 토큰을 추가하기 위한 간편한 설정을 추가하였습니다.

## 이슈 ID는 무엇인가요?

- Closes #176 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

로그인 후 생성된 토큰을 아래 Authorize 버튼을 누르고 입력하면 로그인된 상태로 API 요청이 가능합니다.

![image](https://github.com/user-attachments/assets/49e9a308-9487-4b2b-b3e8-1210812d53e4)

![image](https://github.com/user-attachments/assets/dd1c2fff-ebc5-4c86-b8eb-493118d799ef)


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
