### PR TITLE
채팅 기능의 예외 상황 처리 및 발생할 수 있는 예외 클래스 핸들링

### DIFF
--- a/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ChatErrorMessage {
 
 	MOIM_NOT_FOUND("존재하지 않는 모임에 채팅할 수 없습니다."),
+	INVALID_RECENT_CHAT_ID("최근 조회된 채팅 아이디를 잘 못 입력하였습니다."),
 	;
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -32,6 +32,13 @@ public class ChatService {
 	}
 
 	public ChatFindUnloadedResponse findUnloadedChats(long recentChatId, long moimId, Member member) {
+		moimRepository.findById(moimId)
+			.orElseThrow(() -> new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.MOIM_NOT_FOUND));
+
+		if (recentChatId < 0) {
+			throw new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.INVALID_RECENT_CHAT_ID);
+		}
+
 		List<ChatFindDetailResponse> chats = chatRepository.findAllUnloadedChats(moimId, recentChatId).stream()
 			.map(chat -> ChatFindDetailResponse.toResponse(chat, chat.isMyMessage(member.getId())))
 			.toList();

--- a/backend/src/main/java/mouda/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/mouda/backend/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
@@ -13,21 +14,29 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException exception,
-        HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        String error = exception.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestParameter(
+		MissingServletRequestParameterException exception,
+		HttpHeaders headers, HttpStatusCode status, WebRequest request
+	) {
+		return ResponseEntity.badRequest().body(new ErrorResponse(exception.getParameterName() + "은 NULL일 수 없습니다."));
+	}
 
-        return ResponseEntity.badRequest().body(new ErrorResponse(error));
-    }
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException exception,
+		HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		String error = exception.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
 
-    @ExceptionHandler(MoudaException.class)
-    public ResponseEntity<ErrorResponse> handleMoudaException(MoudaException exception) {
-        return ResponseEntity.status(exception.getHttpStatus()).body(new ErrorResponse(exception.getMessage()));
-    }
+		return ResponseEntity.badRequest().body(new ErrorResponse(error));
+	}
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException() {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse("서버 오류가 발생했습니다."));
-    }
+	@ExceptionHandler(MoudaException.class)
+	public ResponseEntity<ErrorResponse> handleMoudaException(MoudaException exception) {
+		return ResponseEntity.status(exception.getHttpStatus()).body(new ErrorResponse(exception.getMessage()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException() {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse("서버 오류가 발생했습니다."));
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

- 채팅 기능을 구현하는 과정에서 발생할 수 있는 오류를 처리함.
- 클라이언트에서 잘못된 입력 시 스프링에서 던지는 예외를 핸들링함.

## 이슈 ID는 무엇인가요?

- #211 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

![image](https://github.com/user-attachments/assets/bb2ecb3c-9731-4424-83c1-503b2d250438)


만약 `@RequestParam`을 사용하였다면 기본적으로 `required = true`옵션이 걸려있습니다. 
이 경우 `MissingServletRequestParameterException` 예외 클래스가 던져지는데 이를 핸들링하여 우리의 에러 응답을 반환하도록 하였어요. 

그리고 채팅 조회 시 파라미터의 예외를 처리하였습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
