### PR TITLE
현재 참여 인원 및 모임 수정 API 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/moim/domain/Moim.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Moim.java
@@ -143,7 +143,7 @@ public class Moim {
 	}
 
 	public void update(String title, LocalDate date, LocalTime time, String place, int maxPeople,
-		String description) {
+		String description, int currentPeople) {
 		if (!Objects.equals(this.title, title)) {
 			validateTitle(title);
 			this.title = title;
@@ -159,6 +159,8 @@ public class Moim {
 			this.time = time;
 		}
 
+		validateMoimIsFuture(this.date, this.time);
+
 		if (!Objects.equals(this.place, place)) {
 			validatePlace(place);
 			this.place = place;
@@ -166,6 +168,7 @@ public class Moim {
 
 		if (!Objects.equals(this.maxPeople, maxPeople)) {
 			validateMaxPeople(maxPeople);
+			validateMaxPeopleIsUpperThanCurrentPeople(maxPeople, currentPeople);
 			this.maxPeople = maxPeople;
 		}
 
@@ -173,17 +176,21 @@ public class Moim {
 			validateDescription(description);
 			this.description = description;
 		}
-
-		validateMoimIsFuture(this.date, this.time);
 	}
 
-    public boolean isPastMoim() {
-        LocalDateTime dateTime = LocalDateTime.of(date, time);
-        return dateTime.isBefore(LocalDateTime.now());
-    }
+	private void validateMaxPeopleIsUpperThanCurrentPeople(int maxPeople, int currentPeople) {
+		if (maxPeople < currentPeople) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MAX_PEOPLE_IS_LOWER_THAN_CURRENT_PEOPLE);
+		}
+	}
 
-    public boolean isUpcomingMoim() {
-        return !isPastMoim();
-    }
+	public boolean isPastMoim() {
+		LocalDateTime dateTime = LocalDateTime.of(date, time);
+		return dateTime.isBefore(LocalDateTime.now());
+	}
+
+	public boolean isUpcomingMoim() {
+		return !isPastMoim();
+	}
 
 }

--- a/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/moim/exception/MoimErrorMessage.java
@@ -31,7 +31,8 @@ public enum MoimErrorMessage {
 	NOT_ALLOWED_TO_REOPEN("방장만 다시 열 수 있어요."),
 	MOIM_FULL_FOR_REOPEN("모임이 꽉 차서 다시 열 수 없어요."),
 	ALREADY_MOIMING("이미 모집 중인 모임이에요."),
-	NOT_ALLOWED_TO_EDIT("방장만 수정할 수 있어요.");
+	NOT_ALLOWED_TO_EDIT("방장만 수정할 수 있어요."),
+	MAX_PEOPLE_IS_LOWER_THAN_CURRENT_PEOPLE("모임 최대 인원을 현재 인원보다 작게 설정할 수 없어요.");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -64,9 +64,9 @@ public class MoimService {
         return new MoimFindAllResponses(
             moims.stream()
                 .map(moim -> {
-                    List<Member> participants = memberRepository.findAllByMoimId(moim.getId());
+                    int currentPeople = chamyoRepository.countByMoim(moim);
                     boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                    return MoimFindAllResponse.toResponse(moim, participants.size(), isZzimed);
+                    return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
                 })
                 .toList()
         );
@@ -244,9 +244,9 @@ public class MoimService {
         List<MoimFindAllResponse> responses = chamyoStream
             .map(chamyo -> {
                 Moim moim = chamyo.getMoim();
-                int participantCount = memberRepository.findAllByMoimId(moim.getId()).size();
+                int currentPeople = chamyoRepository.countByMoim(moim);
                 boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                return MoimFindAllResponse.toResponse(moim, participantCount, isZzimed);
+                return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
             })
             .toList();
 
@@ -259,9 +259,9 @@ public class MoimService {
         List<MoimFindAllResponse> responses = zzims.stream()
             .map(zzim -> {
                 Moim moim = zzim.getMoim();
-                int participantCount = memberRepository.findAllByMoimId(moim.getId()).size();
+                int currentPeople = chamyoRepository.countByMoim(moim);
                 boolean zzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                return MoimFindAllResponse.toResponse(zzim.getMoim(), participantCount, zzimed);
+                return MoimFindAllResponse.toResponse(zzim.getMoim(), currentPeople, zzimed);
             }).toList();
 
         return new MoimFindAllResponses(responses);

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -1,10 +1,15 @@
 package mouda.backend.moim.service;
 
-import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.*;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import mouda.backend.chamyo.domain.Chamyo;
 import mouda.backend.chamyo.domain.MoimRole;
@@ -31,239 +36,236 @@ import mouda.backend.moim.exception.MoimException;
 import mouda.backend.moim.repository.MoimRepository;
 import mouda.backend.zzim.domain.Zzim;
 import mouda.backend.zzim.repository.ZzimRepository;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @Service
 @RequiredArgsConstructor
 public class MoimService {
 
-    private final MoimRepository moimRepository;
-    private final MemberRepository memberRepository;
-    private final ChamyoRepository chamyoRepository;
-    private final ZzimRepository zzimRepository;
-    private final CommentRepository commentRepository;
+	private final MoimRepository moimRepository;
+	private final MemberRepository memberRepository;
+	private final ChamyoRepository chamyoRepository;
+	private final ZzimRepository zzimRepository;
+	private final CommentRepository commentRepository;
 
-    public Moim createMoim(MoimCreateRequest moimCreateRequest, Member member) {
-        Moim moim = moimRepository.save(moimCreateRequest.toEntity());
-        Chamyo chamyo = Chamyo.builder()
-            .member(member)
-            .moim(moim)
-            .moimRole(MoimRole.MOIMER)
-            .build();
-        chamyoRepository.save(chamyo);
+	public Moim createMoim(MoimCreateRequest moimCreateRequest, Member member) {
+		Moim moim = moimRepository.save(moimCreateRequest.toEntity());
+		Chamyo chamyo = Chamyo.builder()
+			.member(member)
+			.moim(moim)
+			.moimRole(MoimRole.MOIMER)
+			.build();
+		chamyoRepository.save(chamyo);
 
-        return moim;
-    }
+		return moim;
+	}
 
-    @Transactional(readOnly = true)
-    public MoimFindAllResponses findAllMoim(Member member) {
-        List<Moim> moims = moimRepository.findAll();
-        return new MoimFindAllResponses(
-            moims.stream()
-                .map(moim -> {
-                    int currentPeople = chamyoRepository.countByMoim(moim);
-                    boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                    return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
-                })
-                .toList()
-        );
-    }
+	@Transactional(readOnly = true)
+	public MoimFindAllResponses findAllMoim(Member member) {
+		List<Moim> moims = moimRepository.findAll();
+		return new MoimFindAllResponses(
+			moims.stream()
+				.map(moim -> {
+					int currentPeople = chamyoRepository.countByMoim(moim);
+					boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
+					return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
+				})
+				.toList()
+		);
+	}
 
-    @Transactional(readOnly = true)
-    public MoimDetailsFindResponse findMoimDetails(long id) {
-        Moim moim = moimRepository.findById(id)
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+	@Transactional(readOnly = true)
+	public MoimDetailsFindResponse findMoimDetails(long id) {
+		Moim moim = moimRepository.findById(id)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
 
-        List<Comment> comments = commentRepository.findAllByMoimIdOrderByCreatedAt(id);
-        List<CommentResponse> commentResponses = toCommentResponse(comments);
+		List<Comment> comments = commentRepository.findAllByMoimIdOrderByCreatedAt(id);
+		List<CommentResponse> commentResponses = toCommentResponse(comments);
 
-        return MoimDetailsFindResponse.toResponse(moim, chamyoRepository.countByMoim(moim), commentResponses);
-    }
+		return MoimDetailsFindResponse.toResponse(moim, chamyoRepository.countByMoim(moim), commentResponses);
+	}
 
-    private List<CommentResponse> toCommentResponse(List<Comment> comments) {
-        Map<Long, List<Comment>> children = comments.stream()
-            .filter(Comment::isChild)
-            .collect(groupingBy(Comment::getParentId));
+	private List<CommentResponse> toCommentResponse(List<Comment> comments) {
+		Map<Long, List<Comment>> children = comments.stream()
+			.filter(Comment::isChild)
+			.collect(groupingBy(Comment::getParentId));
 
-        return comments.stream()
-            .filter(Comment::isParent)
-            .map(comment -> CommentResponse.toResponse(comment, children.getOrDefault(comment.getId(), List.of())))
-            .toList();
-    }
+		return comments.stream()
+			.filter(Comment::isParent)
+			.map(comment -> CommentResponse.toResponse(comment, children.getOrDefault(comment.getId(), List.of())))
+			.toList();
+	}
 
-    @Deprecated
-    public void joinMoim(MoimJoinRequest moimJoinRequest) {
-        Member member = new Member(moimJoinRequest.nickname());
-        Moim moim = moimRepository.findById(moimJoinRequest.moimId())
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+	@Deprecated
+	public void joinMoim(MoimJoinRequest moimJoinRequest) {
+		Member member = new Member(moimJoinRequest.nickname());
+		Moim moim = moimRepository.findById(moimJoinRequest.moimId())
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
 
-        member.joinMoim(moim);
-        memberRepository.save(member);
-        List<Member> participants = memberRepository.findAllByMoimId(moim.getId());
+		member.joinMoim(moim);
+		memberRepository.save(member);
+		List<Member> participants = memberRepository.findAllByMoimId(moim.getId());
 
-        moim.validateAlreadyFullMoim(participants.size());
-    }
+		moim.validateAlreadyFullMoim(participants.size());
+	}
 
-    public void deleteMoim(long id, Member member) {
-        Moim moim = moimRepository.findById(id)
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-        validateCanDeleteMoim(moim, member);
+	public void deleteMoim(long id, Member member) {
+		Moim moim = moimRepository.findById(id)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanDeleteMoim(moim, member);
 
-        chamyoRepository.deleteAllByMoimId(id);
-        zzimRepository.deleteAllByMoimId(id);
-        moimRepository.delete(moim);
-    }
+		chamyoRepository.deleteAllByMoimId(id);
+		zzimRepository.deleteAllByMoimId(id);
+		moimRepository.delete(moim);
+	}
 
-    private void validateCanDeleteMoim(Moim moim, Member member) {
-        MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND))
-            .getMoimRole();
+	private void validateCanDeleteMoim(Moim moim, Member member) {
+		MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND))
+			.getMoimRole();
 
-        if (moimRole != MoimRole.MOIMER) {
-            throw new MoimException(HttpStatus.FORBIDDEN, MoimErrorMessage.NOT_ALLOWED_TO_DELETE);
-        }
-    }
+		if (moimRole != MoimRole.MOIMER) {
+			throw new MoimException(HttpStatus.FORBIDDEN, MoimErrorMessage.NOT_ALLOWED_TO_DELETE);
+		}
+	}
 
-    public void updateMoimStatusById(long id, MoimStatus status) {
-        moimRepository.updateMoimStatusById(id, status);
-    }
+	public void updateMoimStatusById(long id, MoimStatus status) {
+		moimRepository.updateMoimStatusById(id, status);
+	}
 
-    public void createComment(Member member, Long moimId, CommentCreateRequest commentCreateRequest) {
-        Moim moim = moimRepository.findById(moimId).orElseThrow(
-            () -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND)
-        );
+	public void createComment(Member member, Long moimId, CommentCreateRequest commentCreateRequest) {
+		Moim moim = moimRepository.findById(moimId).orElseThrow(
+			() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND)
+		);
 
-        Long parentId = commentCreateRequest.parentId();
-        if (parentId != null && !commentRepository.existsById(parentId)) {
-            throw new CommentException(HttpStatus.BAD_REQUEST, CommentErrorMessage.PARENT_NOT_FOUND);
-        }
+		Long parentId = commentCreateRequest.parentId();
+		if (parentId != null && !commentRepository.existsById(parentId)) {
+			throw new CommentException(HttpStatus.BAD_REQUEST, CommentErrorMessage.PARENT_NOT_FOUND);
+		}
 
-        commentRepository.save(commentCreateRequest.toEntity(moim, member));
-    }
+		commentRepository.save(commentCreateRequest.toEntity(moim, member));
+	}
 
-    public void completeMoim(Long moimId, Member member) {
-        Moim moim = moimRepository.findById(moimId)
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-        validateCanCompleteMoim(moim, member);
+	public void completeMoim(Long moimId, Member member) {
+		Moim moim = moimRepository.findById(moimId)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanCompleteMoim(moim, member);
 
-        moimRepository.updateMoimStatusById(moimId, MoimStatus.COMPLETED);
-    }
+		moimRepository.updateMoimStatusById(moimId, MoimStatus.COMPLETED);
+	}
 
-    private void validateCanCompleteMoim(Moim moim, Member member) {
-        validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_COMPLETE);
-        MoimStatus moimStatus = moim.getMoimStatus();
-        if (moimStatus == MoimStatus.COMPLETED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_COMPLETED);
-        }
-        if (moimStatus == MoimStatus.CANCELED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
-        }
-    }
+	private void validateCanCompleteMoim(Moim moim, Member member) {
+		validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_COMPLETE);
+		MoimStatus moimStatus = moim.getMoimStatus();
+		if (moimStatus == MoimStatus.COMPLETED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_COMPLETED);
+		}
+		if (moimStatus == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+	}
 
-    public void cancelMoim(Long moimId, Member member) {
-        Moim moim = moimRepository.findById(moimId)
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-        validateCanCancelMoim(moim, member);
+	public void cancelMoim(Long moimId, Member member) {
+		Moim moim = moimRepository.findById(moimId)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanCancelMoim(moim, member);
 
-        moimRepository.updateMoimStatusById(moimId, MoimStatus.CANCELED);
-    }
+		moimRepository.updateMoimStatusById(moimId, MoimStatus.CANCELED);
+	}
 
-    private void validateCanCancelMoim(Moim moim, Member member) {
-        validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_CANCEL);
-        if (moim.getMoimStatus() == MoimStatus.CANCELED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
-        }
-    }
+	private void validateCanCancelMoim(Moim moim, Member member) {
+		validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_CANCEL);
+		if (moim.getMoimStatus() == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+	}
 
-    public void reopenMoim(Long moimId, Member member) {
-        Moim moim = moimRepository.findById(moimId)
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-        validateCanReopenMoim(moim, member);
+	public void reopenMoim(Long moimId, Member member) {
+		Moim moim = moimRepository.findById(moimId)
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanReopenMoim(moim, member);
 
-        moimRepository.updateMoimStatusById(moimId, MoimStatus.MOIMING);
-    }
+		moimRepository.updateMoimStatusById(moimId, MoimStatus.MOIMING);
+	}
 
-    private void validateCanReopenMoim(Moim moim, Member member) {
-        validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_REOPEN);
-        int currentPeople = chamyoRepository.countByMoim(moim);
-        if (currentPeople >= moim.getMaxPeople()) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_FULL_FOR_REOPEN);
-        }
-        MoimStatus moimStatus = moim.getMoimStatus();
-        if (moimStatus == MoimStatus.CANCELED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
-        }
-        if (moimStatus == MoimStatus.MOIMING) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_MOIMING);
-        }
-    }
+	private void validateCanReopenMoim(Moim moim, Member member) {
+		validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_REOPEN);
+		int currentPeople = chamyoRepository.countByMoim(moim);
+		if (currentPeople >= moim.getMaxPeople()) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_FULL_FOR_REOPEN);
+		}
+		MoimStatus moimStatus = moim.getMoimStatus();
+		if (moimStatus == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+		if (moimStatus == MoimStatus.MOIMING) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_MOIMING);
+		}
+	}
 
-    private void validateIsMoimerWithErrorMessage(Moim moim, Member member, MoimErrorMessage errorMessage) {
-        MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND))
-            .getMoimRole();
-        if (moimRole != MoimRole.MOIMER) {
-            throw new MoimException(HttpStatus.FORBIDDEN, errorMessage);
-        }
-    }
+	private void validateIsMoimerWithErrorMessage(Moim moim, Member member, MoimErrorMessage errorMessage) {
+		MoimRole moimRole = chamyoRepository.findByMoimIdAndMemberId(moim.getId(), member.getId())
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND))
+			.getMoimRole();
+		if (moimRole != MoimRole.MOIMER) {
+			throw new MoimException(HttpStatus.FORBIDDEN, errorMessage);
+		}
+	}
 
-    public void editMoim(MoimEditRequest request, Member member) {
-        Moim moim = moimRepository.findById(request.moimId())
-            .orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-        validateCanEditMoim(moim, member);
+	public void editMoim(MoimEditRequest request, Member member) {
+		Moim moim = moimRepository.findById(request.moimId())
+			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
+		validateCanEditMoim(moim, member);
 
-        moim.update(request.title(), request.date(), request.time(), request.place(), request.maxPeople(),
-            request.description());
-        moimRepository.save(moim);
-    }
+		moim.update(request.title(), request.date(), request.time(), request.place(), request.maxPeople(),
+			request.description(), chamyoRepository.countByMoim(moim));
+		moimRepository.save(moim);
+	}
 
-    private void validateCanEditMoim(Moim moim, Member member) {
-        validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_EDIT);
-        MoimStatus moimStatus = moim.getMoimStatus();
-        if (moimStatus == MoimStatus.COMPLETED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_COMPLETED);
-        }
-        if (moimStatus == MoimStatus.CANCELED) {
-            throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
-        }
-    }
+	private void validateCanEditMoim(Moim moim, Member member) {
+		validateIsMoimerWithErrorMessage(moim, member, MoimErrorMessage.NOT_ALLOWED_TO_EDIT);
+		MoimStatus moimStatus = moim.getMoimStatus();
+		if (moimStatus == MoimStatus.COMPLETED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.ALREADY_COMPLETED);
+		}
+		if (moimStatus == MoimStatus.CANCELED) {
+			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.MOIM_CANCELED);
+		}
+	}
 
-    public MoimFindAllResponses findAllMyMoim(Member member, FilterType filter) {
-        Stream<Chamyo> chamyoStream = chamyoRepository.findAllByMemberId(member.getId()).stream();
+	public MoimFindAllResponses findAllMyMoim(Member member, FilterType filter) {
+		Stream<Chamyo> chamyoStream = chamyoRepository.findAllByMemberId(member.getId()).stream();
 
-        if (filter == FilterType.PAST) {
-            chamyoStream = chamyoStream.filter(chamyo -> chamyo.getMoim().isPastMoim());
-        }
-        if (filter == FilterType.UPCOMING) {
-            chamyoStream = chamyoStream.filter(chamyo -> chamyo.getMoim().isUpcomingMoim());
-        }
+		if (filter == FilterType.PAST) {
+			chamyoStream = chamyoStream.filter(chamyo -> chamyo.getMoim().isPastMoim());
+		}
+		if (filter == FilterType.UPCOMING) {
+			chamyoStream = chamyoStream.filter(chamyo -> chamyo.getMoim().isUpcomingMoim());
+		}
 
-        List<MoimFindAllResponse> responses = chamyoStream
-            .map(chamyo -> {
-                Moim moim = chamyo.getMoim();
-                int currentPeople = chamyoRepository.countByMoim(moim);
-                boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
-            })
-            .toList();
+		List<MoimFindAllResponse> responses = chamyoStream
+			.map(chamyo -> {
+				Moim moim = chamyo.getMoim();
+				int currentPeople = chamyoRepository.countByMoim(moim);
+				boolean isZzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
+				return MoimFindAllResponse.toResponse(moim, currentPeople, isZzimed);
+			})
+			.toList();
 
-        return new MoimFindAllResponses(responses);
-    }
+		return new MoimFindAllResponses(responses);
+	}
 
-    public MoimFindAllResponses findZzimedMoim(Member member) {
-        List<Zzim> zzims = zzimRepository.findAllByMemberId(member.getId());
+	public MoimFindAllResponses findZzimedMoim(Member member) {
+		List<Zzim> zzims = zzimRepository.findAllByMemberId(member.getId());
 
-        List<MoimFindAllResponse> responses = zzims.stream()
-            .map(zzim -> {
-                Moim moim = zzim.getMoim();
-                int currentPeople = chamyoRepository.countByMoim(moim);
-                boolean zzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
-                return MoimFindAllResponse.toResponse(zzim.getMoim(), currentPeople, zzimed);
-            }).toList();
+		List<MoimFindAllResponse> responses = zzims.stream()
+			.map(zzim -> {
+				Moim moim = zzim.getMoim();
+				int currentPeople = chamyoRepository.countByMoim(moim);
+				boolean zzimed = zzimRepository.existsByMoimIdAndMemberId(moim.getId(), member.getId());
+				return MoimFindAllResponse.toResponse(zzim.getMoim(), currentPeople, zzimed);
+			}).toList();
 
-        return new MoimFindAllResponses(responses);
-    }
+		return new MoimFindAllResponses(responses);
+	}
 }

--- a/backend/src/test/java/mouda/backend/moim/domain/MoimTest.java
+++ b/backend/src/test/java/mouda/backend/moim/domain/MoimTest.java
@@ -204,32 +204,37 @@ class MoimTest {
 		@Test
 		void fail_whenTitleIsTooLong() {
 			String longTitle = "a".repeat(31);
-			assertThrows(MoimException.class, () -> moim.update(longTitle, DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(longTitle, DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("제목이 빈 문자열이면 수정할 수 없다.")
 		@Test
 		void fail_whenTitleDoesNotExists() {
-			assertThrows(MoimException.class, () -> moim.update("", DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update("", DATE, TIME, PLACE, MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("날짜가 null이면 수정할 수 없다.")
 		@Test
 		void fail_whenDateIsNull() {
-			assertThrows(MoimException.class, () -> moim.update(TITLE, null, TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, null, TIME, PLACE, MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("시간이 null이면 수정할 수 없다.")
 		@Test
 		void fail_whenTimeIsNull() {
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, null, PLACE, MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, null, PLACE, MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("모임 날짜가 현재보다 과거이면 수정할 수 없다.")
 		@Test
 		void fail_whenDateIsPast() {
 			assertThrows(MoimException.class,
-				() -> moim.update(TITLE, LocalDate.now().minusDays(1), TIME, PLACE, MAX_PEOPLE, DESCRIPTION));
+				() -> moim.update(TITLE, LocalDate.now().minusDays(1), TIME, PLACE, MAX_PEOPLE, DESCRIPTION,
+					MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("날짜는 같고, 시간이 현재보다 과거이면 수정할 수 없다.")
@@ -237,39 +242,51 @@ class MoimTest {
 		void fail_whenTimeIsPast() {
 			assertThrows(MoimException.class,
 				() -> moim.update(TITLE, LocalDate.now(), LocalTime.now().minusHours(1), PLACE, MAX_PEOPLE,
-					DESCRIPTION));
+					DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("장소가 빈 문자열이면 수정할 수 없다.")
 		@Test
 		void fail_whenPlaceIsBlank() {
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, "", MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, "", MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("장소 길이가 제한을 초과하면 수정할 수 없다.")
 		@Test
 		void fail_whenPlaceIsTooLong() {
 			String longPlace = "a".repeat(101);
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, longPlace, MAX_PEOPLE, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, longPlace, MAX_PEOPLE, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("모임 최대 인원이 1보다 작으면 수정할 수 없다.")
 		@Test
 		void fail_whenMaxPeopleIsTooSmall() {
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, 0, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, PLACE, 0, DESCRIPTION, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("모임 최대 인원이 제한을 초과하면 수정할 수 없다.")
 		@Test
 		void fail_whenMaxPeopleIsTooMany() {
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, 100, DESCRIPTION));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, PLACE, 100, DESCRIPTION, MAX_PEOPLE + 1));
+		}
+
+		@DisplayName("모임 최대 인원이 현재 참여 인원보다 적으면 수정할 수 없다.")
+		@Test
+		void fail_whenMaxPeopleIsLowerThanCurrentPeople() {
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, PLACE, MAX_PEOPLE - 1, DESCRIPTION, MAX_PEOPLE));
 		}
 
 		@DisplayName("설명의 길이가 길면 수정할 수 없다.")
 		@Test
 		void fail_whenDescriptionIsTooLong() {
 			String longDescription = "a".repeat(1001);
-			assertThrows(MoimException.class, () -> moim.update(TITLE, DATE, TIME, PLACE, MAX_PEOPLE, longDescription));
+			assertThrows(MoimException.class,
+				() -> moim.update(TITLE, DATE, TIME, PLACE, MAX_PEOPLE, longDescription, MAX_PEOPLE + 1));
 		}
 
 		@DisplayName("모임 객체를 수정한다.")
@@ -279,10 +296,10 @@ class MoimTest {
 			LocalDate newDate = LocalDate.now().plusDays(2);
 			LocalTime newTime = LocalTime.now().plusHours(2);
 			String newPlace = "서울시 강남구 강남대로 10길 5";
-			int newMaxPeople = 10;
+			int newMaxPeople = MAX_PEOPLE + 1;
 			String newDescription = "축구하실 분 구합니다.";
 
-			moim.update(newTitle, newDate, newTime, newPlace, newMaxPeople, newDescription);
+			moim.update(newTitle, newDate, newTime, newPlace, newMaxPeople, newDescription, MAX_PEOPLE);
 
 			assertEquals(newTitle, moim.getTitle());
 			assertEquals(newDate, moim.getDate());


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

- 메인 페이지에서 현재 참여 인원이 0명으로 표시되는 문제를 해결했어요
- 모임을 수정할 때 최대 인원수를 현재 참여 인원수보다 적게 설정할 수 없도록 수정했어요.(400 에러, "모임 최대 인원을 현재 인원보다 작게 설정할 수 없어요.") 


## 이슈 ID는 무엇인가요?

- #218 

## 설명

- 모임 조회 테스트는 테바가 설정한거랑 섞여서, 일단 임시로 짜서 돌려보기만 했고 pr에 올리진 않았어요.
- **중요**: 앞으로 현재 참여 인원은 `chamyoRepository.countByMoim(Moim moim)`을 이용해서 조회해주세요!