### PR TITLE
해주세요 작성 및 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/mouda/backend/exception/GlobalExceptionHandler.java
@@ -36,7 +36,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	}
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handleException() {
+	public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+		exception.printStackTrace();
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse("서버 오류가 발생했습니다."));
 	}
 }

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -1,5 +1,7 @@
 package mouda.backend.member.domain;
 
+import java.util.Objects;
+
 import org.springframework.http.HttpStatus;
 
 import jakarta.persistence.Entity;
@@ -21,7 +23,7 @@ import mouda.backend.moim.exception.MoimException;
 public class Member {
 
 	private static final int NICKNAME_MAX_LENGTH = 10;
-	
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -48,5 +50,20 @@ public class Member {
 
 	public void joinMoim(Moim moim) {
 		this.moim = moim;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Member member = (Member)o;
+		return Objects.equals(id, member.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
 	}
 }

--- a/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
+++ b/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
@@ -1,6 +1,8 @@
 package mouda.backend.please.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +32,12 @@ public class PleaseController {
 		Please please = pleaseService.createPlease(member, pleaseCreateRequest);
 
 		return ResponseEntity.ok().body(new RestResponse<>(please.getId()));
+	}
+
+	@DeleteMapping("/{pleaseId}")
+	public ResponseEntity<Void> deletePlease(@LoginMember Member member, @PathVariable Long pleaseId) {
+		pleaseService.deletePlease(member, pleaseId);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
+++ b/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
@@ -22,10 +22,11 @@ import mouda.backend.please.service.PleaseService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/please")
-public class PleaseController {
+public class PleaseController implements PleaseSwagger {
 
 	private final PleaseService pleaseService;
 
+	@Override
 	@PostMapping
 	public ResponseEntity<RestResponse<Long>> createPlease(
 		@LoginMember Member member,
@@ -36,6 +37,7 @@ public class PleaseController {
 		return ResponseEntity.ok().body(new RestResponse<>(please.getId()));
 	}
 
+	@Override
 	@DeleteMapping("/{pleaseId}")
 	public ResponseEntity<Void> deletePlease(@LoginMember Member member, @PathVariable Long pleaseId) {
 		pleaseService.deletePlease(member, pleaseId);
@@ -43,6 +45,7 @@ public class PleaseController {
 		return ResponseEntity.ok().build();
 	}
 
+	@Override
 	@GetMapping
 	public ResponseEntity<RestResponse<PleaseFindAllResponses>> findAllPlease(@LoginMember Member member) {
 		PleaseFindAllResponses responses = pleaseService.findAllPlease(member);

--- a/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
+++ b/backend/src/main/java/mouda/backend/please/controller/PleaseController.java
@@ -1,0 +1,34 @@
+package mouda.backend.please.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mouda.backend.common.RestResponse;
+import mouda.backend.config.argumentresolver.LoginMember;
+import mouda.backend.member.domain.Member;
+import mouda.backend.please.domain.Please;
+import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.service.PleaseService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/please")
+public class PleaseController {
+
+	private final PleaseService pleaseService;
+
+	@PostMapping
+	public ResponseEntity<RestResponse<Long>> createPlease(
+		@LoginMember Member member,
+		@Valid @RequestBody PleaseCreateRequest pleaseCreateRequest
+	) {
+		Please please = pleaseService.createPlease(member, pleaseCreateRequest);
+
+		return ResponseEntity.ok().body(new RestResponse<>(please.getId()));
+	}
+}

--- a/backend/src/main/java/mouda/backend/please/controller/PleaseSwagger.java
+++ b/backend/src/main/java/mouda/backend/please/controller/PleaseSwagger.java
@@ -1,0 +1,39 @@
+package mouda.backend.please.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import mouda.backend.common.RestResponse;
+import mouda.backend.config.argumentresolver.LoginMember;
+import mouda.backend.member.domain.Member;
+import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.dto.response.PleaseFindAllResponses;
+
+public interface PleaseSwagger {
+
+	@Operation(summary = "해주세요 생성", description = "해주세요를 생성한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "해주세요 생성 성공!"),
+	})
+	ResponseEntity<RestResponse<Long>> createPlease(
+		@LoginMember Member member,
+		@Valid @RequestBody PleaseCreateRequest pleaseCreateRequest
+	);
+
+	@Operation(summary = "해주세요 삭제", description = "해주세요를 삭제한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "해주세요 삭제 성공!"),
+	})
+	ResponseEntity<Void> deletePlease(@LoginMember Member member, @PathVariable Long pleaseId);
+
+	@Operation(summary = "해주세요 목록 조회", description = "해주세요 목록을 조회한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "해주세요 목록 조회 성공!"),
+	})
+	ResponseEntity<RestResponse<PleaseFindAllResponses>> findAllPlease(@LoginMember Member member);
+}

--- a/backend/src/main/java/mouda/backend/please/domain/Please.java
+++ b/backend/src/main/java/mouda/backend/please/domain/Please.java
@@ -29,8 +29,22 @@ public class Please {
 
 	@Builder
 	public Please(String title, String description, long authorId) {
+		validateTitle(title);
+		validateDescription(description);
 		this.title = title;
 		this.description = description;
 		this.authorId = authorId;
+	}
+
+	private void validateTitle(String title) {
+		if (title == null || title.isEmpty()) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private void validateDescription(String description) {
+		if (description == null || description.isEmpty()) {
+			throw new IllegalArgumentException();
+		}
 	}
 }

--- a/backend/src/main/java/mouda/backend/please/domain/Please.java
+++ b/backend/src/main/java/mouda/backend/please/domain/Please.java
@@ -47,4 +47,8 @@ public class Please {
 			throw new IllegalArgumentException();
 		}
 	}
+
+	public boolean isNotAuthor(long memberId) {
+		return authorId != memberId;
+	}
 }

--- a/backend/src/main/java/mouda/backend/please/domain/Please.java
+++ b/backend/src/main/java/mouda/backend/please/domain/Please.java
@@ -1,5 +1,7 @@
 package mouda.backend.please.domain;
 
+import org.springframework.http.HttpStatus;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -8,6 +10,8 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.please.exception.PleaseErrorMessage;
+import mouda.backend.please.exception.PleaseException;
 
 @Entity
 @Getter
@@ -38,13 +42,13 @@ public class Please {
 
 	private void validateTitle(String title) {
 		if (title == null || title.isEmpty()) {
-			throw new IllegalArgumentException();
+			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.TITLE_NOT_EXIST.getMessage());
 		}
 	}
 
 	private void validateDescription(String description) {
 		if (description == null || description.isEmpty()) {
-			throw new IllegalArgumentException();
+			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.DESCRIPTION_NOT_EXIST.getMessage());
 		}
 	}
 

--- a/backend/src/main/java/mouda/backend/please/domain/Please.java
+++ b/backend/src/main/java/mouda/backend/please/domain/Please.java
@@ -42,13 +42,13 @@ public class Please {
 
 	private void validateTitle(String title) {
 		if (title == null || title.isEmpty()) {
-			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.TITLE_NOT_EXIST.getMessage());
+			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.TITLE_NOT_EXIST);
 		}
 	}
 
 	private void validateDescription(String description) {
 		if (description == null || description.isEmpty()) {
-			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.DESCRIPTION_NOT_EXIST.getMessage());
+			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.DESCRIPTION_NOT_EXIST);
 		}
 	}
 

--- a/backend/src/main/java/mouda/backend/please/dto/request/PleaseCreateRequest.java
+++ b/backend/src/main/java/mouda/backend/please/dto/request/PleaseCreateRequest.java
@@ -1,0 +1,22 @@
+package mouda.backend.please.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import mouda.backend.please.domain.Please;
+
+public record PleaseCreateRequest(
+
+	@NotNull
+	String title,
+
+	@NotNull
+	String description
+) {
+
+	public Please toEntity(long memberId) {
+		return Please.builder()
+			.title(title)
+			.description(description)
+			.authorId(memberId)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/please/exception/PleaseErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/please/exception/PleaseErrorMessage.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public enum PleaseErrorMessage {
 
 	NOT_FOUND("해주세요가 존재하지 않습니다."),
+	TITLE_NOT_EXIST("제목이 존재하지 않습니다."),
+	DESCRIPTION_NOT_EXIST("내용이 존재하지 않습니다."),
 	NOT_ALLOWED_TO_DELETE("삭제 권한이 없습니다.");
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/please/exception/PleaseErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/please/exception/PleaseErrorMessage.java
@@ -1,0 +1,14 @@
+package mouda.backend.please.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PleaseErrorMessage {
+
+	NOT_FOUND("해주세요가 존재하지 않습니다."),
+	NOT_ALLOWED_TO_DELETE("삭제 권한이 없습니다.");
+
+	private final String message;
+}

--- a/backend/src/main/java/mouda/backend/please/exception/PleaseException.java
+++ b/backend/src/main/java/mouda/backend/please/exception/PleaseException.java
@@ -6,7 +6,7 @@ import mouda.backend.exception.MoudaException;
 
 public class PleaseException extends MoudaException {
 
-	public PleaseException(HttpStatus httpStatus, String message) {
-		super(httpStatus, message);
+	public PleaseException(HttpStatus httpStatus, PleaseErrorMessage message) {
+		super(httpStatus, message.getMessage());
 	}
 }

--- a/backend/src/main/java/mouda/backend/please/exception/PleaseException.java
+++ b/backend/src/main/java/mouda/backend/please/exception/PleaseException.java
@@ -1,0 +1,12 @@
+package mouda.backend.please.exception;
+
+import org.springframework.http.HttpStatus;
+
+import mouda.backend.exception.MoudaException;
+
+public class PleaseException extends MoudaException {
+
+	public PleaseException(HttpStatus httpStatus, String message) {
+		super(httpStatus, message);
+	}
+}

--- a/backend/src/main/java/mouda/backend/please/repository/PleaseRepository.java
+++ b/backend/src/main/java/mouda/backend/please/repository/PleaseRepository.java
@@ -1,0 +1,8 @@
+package mouda.backend.please.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mouda.backend.please.domain.Please;
+
+public interface PleaseRepository extends JpaRepository<Please, Long> {
+}

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -1,5 +1,6 @@
 package mouda.backend.please.service;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import mouda.backend.member.domain.Member;
 import mouda.backend.please.domain.Please;
 import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.exception.PleaseErrorMessage;
+import mouda.backend.please.exception.PleaseException;
 import mouda.backend.please.repository.PleaseRepository;
 
 @Service
@@ -24,10 +27,10 @@ public class PleaseService {
 
 	public void deletePlease(Member member, Long pleaseId) {
 		Please please = pleaseRepository.findById(pleaseId)
-			.orElseThrow();
+			.orElseThrow(() -> new PleaseException(HttpStatus.NOT_FOUND, PleaseErrorMessage.NOT_FOUND.getMessage()));
 
 		if (please.isNotAuthor(member.getId())) {
-			throw new IllegalArgumentException();
+			throw new PleaseException(HttpStatus.FORBIDDEN, PleaseErrorMessage.NOT_ALLOWED_TO_DELETE.getMessage());
 		}
 
 		pleaseRepository.deleteById(pleaseId);

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -33,10 +33,10 @@ public class PleaseService {
 
 	public void deletePlease(Member member, Long pleaseId) {
 		Please please = pleaseRepository.findById(pleaseId)
-			.orElseThrow(() -> new PleaseException(HttpStatus.NOT_FOUND, PleaseErrorMessage.NOT_FOUND.getMessage()));
+			.orElseThrow(() -> new PleaseException(HttpStatus.NOT_FOUND, PleaseErrorMessage.NOT_FOUND));
 
 		if (please.isNotAuthor(member.getId())) {
-			throw new PleaseException(HttpStatus.FORBIDDEN, PleaseErrorMessage.NOT_ALLOWED_TO_DELETE.getMessage());
+			throw new PleaseException(HttpStatus.FORBIDDEN, PleaseErrorMessage.NOT_ALLOWED_TO_DELETE);
 		}
 
 		pleaseRepository.deleteById(pleaseId);

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -1,0 +1,24 @@
+package mouda.backend.please.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.member.domain.Member;
+import mouda.backend.please.domain.Please;
+import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.repository.PleaseRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PleaseService {
+
+	private final PleaseRepository pleaseRepository;
+
+	public Please createPlease(Member member, PleaseCreateRequest pleaseCreateRequest) {
+		Please please = pleaseCreateRequest.toEntity(member.getId());
+
+		return pleaseRepository.save(please);
+	}
+}

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -21,4 +21,15 @@ public class PleaseService {
 
 		return pleaseRepository.save(please);
 	}
+
+	public void deletePlease(Member member, Long pleaseId) {
+		Please please = pleaseRepository.findById(pleaseId)
+			.orElseThrow();
+
+		if (please.isNotAuthor(member.getId())) {
+			throw new IllegalArgumentException();
+		}
+
+		pleaseRepository.deleteById(pleaseId);
+	}
 }

--- a/backend/src/test/java/mouda/backend/config/DatabaseCleaner.java
+++ b/backend/src/test/java/mouda/backend/config/DatabaseCleaner.java
@@ -30,6 +30,9 @@ public class DatabaseCleaner {
 		entityManager.createNativeQuery("DELETE FROM CHAMYO").executeUpdate();
 		entityManager.createNativeQuery("ALTER TABLE CHAMYO alter column id restart with 1").executeUpdate();
 
+		entityManager.createNativeQuery("DELETE FROM PLEASE").executeUpdate();
+		entityManager.createNativeQuery("ALTER TABLE PLEASE alter column id restart with 1").executeUpdate();
+
 		entityManager.createNativeQuery("DELETE FROM MEMBER").executeUpdate();
 		entityManager.createNativeQuery("ALTER TABLE MEMBER alter column id restart with 1").executeUpdate();
 

--- a/backend/src/test/java/mouda/backend/fixture/PleaseFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/PleaseFixture.java
@@ -1,0 +1,22 @@
+package mouda.backend.fixture;
+
+import mouda.backend.please.domain.Please;
+
+public class PleaseFixture {
+
+	public static Please getPlease() {
+		return Please.builder()
+			.title("치킨 사주세요")
+			.description("제발요")
+			.authorId(1L)
+			.build();
+	}
+
+	public static Please getPlease(long id) {
+		return Please.builder()
+			.title("라라스윗 사주세요")
+			.description("제발요")
+			.authorId(id)
+			.build();
+	}
+}

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -17,6 +17,7 @@ import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.please.domain.Please;
 import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.exception.PleaseException;
 
 @SpringBootTest
 class PleaseServiceTest {
@@ -58,7 +59,7 @@ class PleaseServiceTest {
 			Member tebah = memberRepository.save(MemberFixture.getTebah());
 
 			assertThatThrownBy(() -> pleaseService.createPlease(tebah, request))
-				.isInstanceOf(IllegalArgumentException.class);
+				.isInstanceOf(PleaseException.class);
 		}
 
 		@DisplayName("해주세요의 설명이 비어있으면 해주세요 생성에 실패한다.")
@@ -69,7 +70,7 @@ class PleaseServiceTest {
 			Member tebah = memberRepository.save(MemberFixture.getTebah());
 
 			assertThatThrownBy(() -> pleaseService.createPlease(tebah, request))
-				.isInstanceOf(IllegalArgumentException.class);
+				.isInstanceOf(PleaseException.class);
 		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -2,6 +2,8 @@ package mouda.backend.please.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,17 +15,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import mouda.backend.config.DatabaseCleaner;
 import mouda.backend.fixture.MemberFixture;
+import mouda.backend.fixture.PleaseFixture;
 import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.please.domain.Please;
 import mouda.backend.please.dto.request.PleaseCreateRequest;
 import mouda.backend.please.exception.PleaseException;
+import mouda.backend.please.repository.PleaseRepository;
 
 @SpringBootTest
 class PleaseServiceTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private PleaseRepository pleaseRepository;
 
 	@Autowired
 	private PleaseService pleaseService;
@@ -70,6 +77,43 @@ class PleaseServiceTest {
 			Member tebah = memberRepository.save(MemberFixture.getTebah());
 
 			assertThatThrownBy(() -> pleaseService.createPlease(tebah, request))
+				.isInstanceOf(PleaseException.class);
+		}
+	}
+
+	@DisplayName("해주세요 삭제 테스트")
+	@Nested
+	class PleaseDeleteTest {
+
+		@DisplayName("해주세요를 성공적으로 삭제한다.")
+		@Test
+		void success() {
+			Member member = memberRepository.save(MemberFixture.getTebah());
+			Please please = pleaseRepository.save(PleaseFixture.getPlease());
+
+			pleaseService.deletePlease(member, please.getId());
+
+			List<Please> pleases = pleaseRepository.findAll();
+			assertThat(pleases).hasSize(0);
+		}
+
+		@DisplayName("해주세요 작성자가 아니라면 삭제에 실패한다.")
+		@Test
+		void failToDeleteWithNonAuthor() {
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+			Please please = pleaseRepository.save(PleaseFixture.getPlease(tebah.getId()));
+			Member anna = memberRepository.save(MemberFixture.getAnna());
+
+			assertThatThrownBy(() -> pleaseService.deletePlease(anna, please.getId()))
+				.isInstanceOf(PleaseException.class);
+		}
+
+		@DisplayName("해주세요가 존재하지 않으면 삭제에 실패한다.")
+		@Test
+		void failToDeleteWithNotExistPlease() {
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+
+			assertThatThrownBy(() -> pleaseService.deletePlease(tebah, 0L))
 				.isInstanceOf(PleaseException.class);
 		}
 	}

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -1,0 +1,75 @@
+package mouda.backend.please.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import mouda.backend.config.DatabaseCleaner;
+import mouda.backend.fixture.MemberFixture;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+import mouda.backend.please.domain.Please;
+import mouda.backend.please.dto.request.PleaseCreateRequest;
+
+@SpringBootTest
+class PleaseServiceTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private PleaseService pleaseService;
+
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@AfterEach
+	void cleanUp() {
+		databaseCleaner.cleanUp();
+	}
+
+	@DisplayName("해주세요 생성 테스트")
+	@Nested
+	class PleaseCreateTest {
+
+		@DisplayName("해주세요를 성공적으로 생성한다.")
+		@Test
+		void success() {
+			PleaseCreateRequest request = new PleaseCreateRequest("치킨 사주세요", "제발요");
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+
+			Please please = pleaseService.createPlease(tebah, request);
+
+			assertThat(please.getId()).isEqualTo(1L);
+		}
+
+		@DisplayName("해주세요의 제목이 비어있으면 해주세요 생성에 실패한다.")
+		@NullAndEmptySource
+		@ParameterizedTest
+		void failToCreatePleaseWithoutTitle(String emptyTitle) {
+			PleaseCreateRequest request = new PleaseCreateRequest(emptyTitle, "제발요");
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+
+			assertThatThrownBy(() -> pleaseService.createPlease(tebah, request))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+
+		@DisplayName("해주세요의 설명이 비어있으면 해주세요 생성에 실패한다.")
+		@NullAndEmptySource
+		@ParameterizedTest
+		void failToCreatePleaseWithoutDescription(String emptyDescription) {
+			PleaseCreateRequest request = new PleaseCreateRequest("피자 사주세요", emptyDescription);
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+
+			assertThatThrownBy(() -> pleaseService.createPlease(tebah, request))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

- 해주세요 작성 기능 추가
- 해주세요 삭제 기능 추가

## 이슈 ID는 무엇인가요?

- closed #224 

## 설명

- Please 클래스에 Member 대신 memberId를 필드로 추가했습니다.
  - 해주세요가 익명 기능임을 고려해 닉네임을 조회하지 않아 id 를 참조하도록 설계했습니다.
- 기존 기획이었던 수정 기능 대신 삭제 기능을 추가했습니다.
- 개발 서버에서 오류를 쉽게 파악하기 위해 500에러에 한해 stacktrace를 출력하도록 변경했습니다.
- 멤버의 id를 기준으로 equals와 hashcode를 오버라이딩 했습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
