### PR TITLE
채팅방 목록 미리보기 api 구현 및 마지막으로 읽은 채팅 필드 추가

### DIFF
--- a/backend/src/main/java/mouda/backend/chamyo/domain/Chamyo.java
+++ b/backend/src/main/java/mouda/backend/chamyo/domain/Chamyo.java
@@ -36,10 +36,17 @@ public class Chamyo {
 	@Column(nullable = false)
 	private MoimRole moimRole;
 
+	private long lastReadChatId;
+
 	@Builder
 	public Chamyo(Moim moim, Member member, MoimRole moimRole) {
 		this.moim = moim;
 		this.member = member;
 		this.moimRole = moimRole;
+		this.lastReadChatId = 0L;
+	}
+
+	public void updateLastChat(Long lastReadChatId) {
+		this.lastReadChatId = lastReadChatId;
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -47,7 +47,8 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok(new RestResponse<>(unloadedChats));
 	}
 
-	@GetMapping
+	@Override
+	@GetMapping("/preview")
 	public ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
 		@LoginMember Member member
 	) {
@@ -56,6 +57,8 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok(new RestResponse<>(chatPreviewResponses));
 	}
 
+	@Override
+	@PostMapping("/last")
 	public ResponseEntity<Void> createLastReadChatId(
 		@RequestBody LastReadChatRequest lastReadChatRequest,
 		@LoginMember Member member

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.dto.request.LastReadChatRequest;
 import mouda.backend.chat.dto.response.ChatFindUnloadedResponse;
+import mouda.backend.chat.dto.response.ChatPreviewResponses;
 import mouda.backend.chat.service.ChatService;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
@@ -43,5 +45,23 @@ public class ChatController implements ChatSwagger {
 	) {
 		ChatFindUnloadedResponse unloadedChats = chatService.findUnloadedChats(recentChatId, moimId, member);
 		return ResponseEntity.ok(new RestResponse<>(unloadedChats));
+	}
+
+	@GetMapping
+	public ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
+		@LoginMember Member member
+	) {
+		ChatPreviewResponses chatPreviewResponses = chatService.findChatPreview(member);
+
+		return ResponseEntity.ok(new RestResponse<>(chatPreviewResponses));
+	}
+
+	public ResponseEntity<Void> createLastReadChatId(
+		@RequestBody LastReadChatRequest lastReadChatRequest,
+		@LoginMember Member member
+	) {
+		chatService.createLastChat(lastReadChatRequest, member);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatSwagger.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatSwagger.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.dto.request.LastReadChatRequest;
 import mouda.backend.chat.dto.response.ChatFindUnloadedResponse;
+import mouda.backend.chat.dto.response.ChatPreviewResponses;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.member.domain.Member;
@@ -31,6 +33,23 @@ public interface ChatSwagger {
 	ResponseEntity<RestResponse<ChatFindUnloadedResponse>> findUnloadedChats(
 		@RequestParam Long recentChatId,
 		@RequestParam Long moimId,
+		@LoginMember Member member
+	);
+
+	@Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "채팅방 조회 성공!")
+	})
+	ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
+		@LoginMember Member member
+	);
+
+	@Operation(summary = "마지막 읽은 채팅 저장", description = "마지막 읽은 채팅을 저장한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "마지막 채팅 저장 성공!")
+	})
+	ResponseEntity<Void> createLastReadChatId(
+		@RequestBody LastReadChatRequest lastReadChatRequest,
 		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/chat/dto/request/LastReadChatRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/request/LastReadChatRequest.java
@@ -1,0 +1,7 @@
+package mouda.backend.chat.dto.request;
+
+public record LastReadChatRequest(
+	Long moimId,
+	Long lastReadChatId
+) {
+}

--- a/backend/src/main/java/mouda/backend/chat/dto/request/LastReadChatRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/request/LastReadChatRequest.java
@@ -1,7 +1,12 @@
 package mouda.backend.chat.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record LastReadChatRequest(
+	@NotNull
 	Long moimId,
+
+	@NotNull
 	Long lastReadChatId
 ) {
 }

--- a/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponse.java
@@ -2,7 +2,6 @@ package mouda.backend.chat.dto.response;
 
 import lombok.Builder;
 import mouda.backend.chamyo.domain.Chamyo;
-import mouda.backend.chat.domain.Chat;
 
 @Builder
 public record ChatPreviewResponse(
@@ -15,9 +14,9 @@ public record ChatPreviewResponse(
 ) {
 
 	public static ChatPreviewResponse toResponse(
-		Chat chat,
 		Chamyo chamyo,
 		int currentPeople,
+		String lastContent,
 		long unreadContentCount
 	) {
 		return ChatPreviewResponse.builder()
@@ -25,8 +24,22 @@ public record ChatPreviewResponse(
 			.title(chamyo.getMoim().getTitle())
 			.currentPeople(currentPeople)
 			.beforeMoim(chamyo.getMoim().isPastMoim())
-			.lastContent(chat.getContent())
+			.lastContent(lastContent)
 			.unreadContentCount(unreadContentCount)
+			.build();
+	}
+
+	public static ChatPreviewResponse toResponse(
+		Chamyo chamyo,
+		int currentPeople
+	) {
+		return ChatPreviewResponse.builder()
+			.moimId(chamyo.getMoim().getId())
+			.title(chamyo.getMoim().getTitle())
+			.currentPeople(currentPeople)
+			.beforeMoim(chamyo.getMoim().isPastMoim())
+			.lastContent("")
+			.unreadContentCount(0)
 			.build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponse.java
@@ -1,0 +1,32 @@
+package mouda.backend.chat.dto.response;
+
+import lombok.Builder;
+import mouda.backend.chamyo.domain.Chamyo;
+import mouda.backend.chat.domain.Chat;
+
+@Builder
+public record ChatPreviewResponse(
+	Long moimId,
+	String title,
+	int currentPeople,
+	boolean beforeMoim,
+	String lastContent,
+	long unreadContentCount
+) {
+
+	public static ChatPreviewResponse toResponse(
+		Chat chat,
+		Chamyo chamyo,
+		int currentPeople,
+		long unreadContentCount
+	) {
+		return ChatPreviewResponse.builder()
+			.moimId(chamyo.getMoim().getId())
+			.title(chamyo.getMoim().getTitle())
+			.currentPeople(currentPeople)
+			.beforeMoim(chamyo.getMoim().isPastMoim())
+			.lastContent(chat.getContent())
+			.unreadContentCount(unreadContentCount)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponses.java
+++ b/backend/src/main/java/mouda/backend/chat/dto/response/ChatPreviewResponses.java
@@ -1,0 +1,8 @@
+package mouda.backend.chat.dto.response;
+
+import java.util.List;
+
+public record ChatPreviewResponses(
+	List<ChatPreviewResponse> chatPreviewResponses
+) {
+}

--- a/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
@@ -1,6 +1,7 @@
 package mouda.backend.chat.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,5 +14,5 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 	@Query("SELECT c FROM Chat c WHERE c.moim.id = :moimId AND c.id > :chatId")
 	List<Chat> findAllUnloadedChats(@Param("moimId") long moimId, @Param("chatId") long chatId);
 
-	Chat findLastByOrderById();
+	Optional<Chat> findFirstByMoimIdOrderByIdDesc(long moimId);
 }

--- a/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/mouda/backend/chat/repository/ChatRepository.java
@@ -12,4 +12,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 
 	@Query("SELECT c FROM Chat c WHERE c.moim.id = :moimId AND c.id > :chatId")
 	List<Chat> findAllUnloadedChats(@Param("moimId") long moimId, @Param("chatId") long chatId);
+
+	Chat findLastByOrderById();
 }

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -6,9 +6,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import mouda.backend.chamyo.domain.Chamyo;
 import mouda.backend.chamyo.repository.ChamyoRepository;
 import mouda.backend.chat.domain.Chat;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
+import mouda.backend.chat.dto.request.LastReadChatRequest;
 import mouda.backend.chat.dto.response.ChatFindDetailResponse;
 import mouda.backend.chat.dto.response.ChatFindUnloadedResponse;
 import mouda.backend.chat.exception.ChatErrorMessage;
@@ -51,5 +53,12 @@ public class ChatService {
 			.toList();
 
 		return new ChatFindUnloadedResponse(chats);
+	}
+
+	public void createLastChat(LastReadChatRequest lastReadChatRequest, Member member) {
+		Chamyo chamyo = chamyoRepository.findByMoimIdAndMemberId(lastReadChatRequest.moimId(), member.getId())
+			.orElseThrow(() -> new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.NOT_PARTICIPANT_TO_FIND));
+
+		chamyo.updateLastChat(lastReadChatRequest.lastReadChatId());
 	}
 }

--- a/backend/src/main/java/mouda/backend/moim/domain/Moim.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Moim.java
@@ -82,6 +82,7 @@ public class Moim {
 		this.maxPeople = maxPeople;
 		this.description = description;
 		this.moimStatus = MoimStatus.MOIMING;
+		this.isChatOpened = false;
 	}
 
 	private void validateTitle(String title) {

--- a/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import mouda.backend.chat.domain.Chat;
+import mouda.backend.config.DatabaseCleaner;
 import mouda.backend.fixture.ChatFixture;
 import mouda.backend.fixture.MemberFixture;
 import mouda.backend.fixture.MoimFixture;
@@ -18,7 +20,7 @@ import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.repository.MoimRepository;
 
-@DataJpaTest
+@SpringBootTest
 class ChatRepositoryTest {
 
 	@Autowired
@@ -29,6 +31,14 @@ class ChatRepositoryTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@AfterEach
+	void cleanUp() {
+		databaseCleaner.cleanUp();
+	}
 
 	@DisplayName("모임 아이디가 동일하고 채팅 아이디가 더 큰 채팅 리스트가 조회된다.")
 	@Test

--- a/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/chat/repository/ChatRepositoryTest.java
@@ -51,4 +51,22 @@ class ChatRepositoryTest {
 
 		assertThat(chats).hasSize(1);
 	}
+
+	@DisplayName("해당하는 모임의 가장 최근의 채팅을 보여준다.")
+	@Test
+	void findFirstByMoimIdOrderByIdDesc() {
+		Moim moim = MoimFixture.getCoffeeMoim();
+		Moim savedMoim = moimRepository.save(moim);
+
+		Member member = MemberFixture.getHogee();
+		memberRepository.save(member);
+
+		Chat hogee1 = ChatFixture.getChatWithMemberAtMoim(member, moim);
+		chatRepository.save(hogee1);
+		Chat hogee2 = ChatFixture.getChatWithMemberAtMoim(member, moim);
+		Chat savedLastChat = chatRepository.save(hogee2);
+
+		Chat chat = chatRepository.findFirstByMoimIdOrderByIdDesc(savedMoim.getId()).get();
+		assertThat(chat.getId()).isEqualTo(savedLastChat.getId());
+	}
 }

--- a/backend/src/test/java/mouda/backend/chat/service/ChatServiceTest.java
+++ b/backend/src/test/java/mouda/backend/chat/service/ChatServiceTest.java
@@ -1,0 +1,69 @@
+package mouda.backend.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import mouda.backend.chamyo.domain.Chamyo;
+import mouda.backend.chamyo.domain.MoimRole;
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.chat.dto.response.ChatPreviewResponses;
+import mouda.backend.chat.repository.ChatRepository;
+import mouda.backend.config.DatabaseCleaner;
+import mouda.backend.fixture.MemberFixture;
+import mouda.backend.fixture.MoimFixture;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.repository.MoimRepository;
+
+@SpringBootTest
+class ChatServiceTest {
+
+	@Autowired
+	private ChatRepository chatRepository;
+
+	@Autowired
+	private MoimRepository moimRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private ChamyoRepository chamyoRepository;
+
+	@Autowired
+	private ChatService chatService;
+
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@AfterEach
+	void cleanUp() {
+		databaseCleaner.cleanUp();
+	}
+
+	@DisplayName("열린 채팅방이 없다면 빈 리스트를 반환한다.")
+	@Test
+	void findChatPreview() {
+		Member hogee = MemberFixture.getHogee();
+		memberRepository.save(hogee);
+
+		Moim basketballMoim = MoimFixture.getBasketballMoim();
+		moimRepository.save(basketballMoim);
+
+		Chamyo chamyo = Chamyo.builder()
+			.member(hogee)
+			.moim(basketballMoim)
+			.moimRole(MoimRole.MOIMEE)
+			.build();
+		chamyoRepository.save(chamyo);
+
+		ChatPreviewResponses chatPreview = chatService.findChatPreview(hogee);
+		assertThat(chatPreview.chatPreviewResponses()).isEmpty();
+	}
+}

--- a/backend/src/test/java/mouda/backend/config/ChamyoCreator.java
+++ b/backend/src/test/java/mouda/backend/config/ChamyoCreator.java
@@ -1,46 +1,46 @@
 package mouda.backend.config;
 
-
-import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityManager;
+
 @Component
 public class ChamyoCreator {
 
-    @Autowired
-    private EntityManager entityManager;
+	@Autowired
+	private EntityManager entityManager;
 
-    @Transactional
-    public void setUpTwoPastThreeUpcomingMoim() {
-        entityManager.createNativeQuery(
-            "INSERT INTO Moim (title, date, time, place, max_people, description, moim_status, is_chat_opened) VALUES "
-                + "('과거 축구 모임', DATEADD('DAY', -1, CURRENT_DATE), CURRENT_TIME(), '과거 축구 장소', 10, '축구추구', 'COMPLETED', false), "
-                + "('과거 농구 모임', DATEADD('DAY', -5, CURRENT_DATE), CURRENT_TIME(), '과거 농구 장소', 15, '농구농구', 'CANCELED', true);"
-        ).executeUpdate();
+	@Transactional
+	public void setUpTwoPastThreeUpcomingMoim() {
+		entityManager.createNativeQuery(
+			"INSERT INTO Moim (title, date, time, place, max_people, description, moim_status, is_chat_opened) VALUES "
+				+ "('과거 축구 모임', DATEADD('DAY', -1, CURRENT_DATE), CURRENT_TIME(), '과거 축구 장소', 10, '축구추구', 'COMPLETED', false), "
+				+ "('과거 농구 모임', DATEADD('DAY', -5, CURRENT_DATE), CURRENT_TIME(), '과거 농구 장소', 15, '농구농구', 'CANCELED', true);"
+		).executeUpdate();
 
-        entityManager.createNativeQuery(
-            "INSERT INTO Moim (title, date, time, place, max_people, description, moim_status, is_chat_opened) VALUES "
-                + "('미래 축구 모임', DATEADD('DAY', 5, CURRENT_DATE), CURRENT_TIME(), '축구 장소', 20, '많이 오세요', 'MOIMING', true), "
-                + "('미래 농구 모임', DATEADD('DAY', 10, CURRENT_DATE), CURRENT_TIME(), '농구 장소', 25, '많이 오세요', 'MOIMING', false), "
-                + "('미래 커피 모임', DATEADD('DAY', 15, CURRENT_DATE), CURRENT_TIME(), '커피 장소', 30, '많이 오세요', 'MOIMING', true);"
-        ).executeUpdate();
+		entityManager.createNativeQuery(
+			"INSERT INTO Moim (title, date, time, place, max_people, description, moim_status, is_chat_opened) VALUES "
+				+ "('미래 축구 모임', DATEADD('DAY', 5, CURRENT_DATE), CURRENT_TIME(), '축구 장소', 20, '많이 오세요', 'MOIMING', true), "
+				+ "('미래 농구 모임', DATEADD('DAY', 10, CURRENT_DATE), CURRENT_TIME(), '농구 장소', 25, '많이 오세요', 'MOIMING', false), "
+				+ "('미래 커피 모임', DATEADD('DAY', 15, CURRENT_DATE), CURRENT_TIME(), '커피 장소', 30, '많이 오세요', 'MOIMING', true);"
+		).executeUpdate();
 
-        entityManager.createNativeQuery("INSERT INTO MEMBER (nickname) VALUES ('테바')").executeUpdate();
+		entityManager.createNativeQuery("INSERT INTO MEMBER (nickname) VALUES ('테바')").executeUpdate();
 
-        entityManager.createNativeQuery("INSERT INTO CHAMYO (member_id, moim_id, moim_role) VALUES "
-            + "(1, 1, 'MOIMEE'), "
-            + "(1, 2, 'MOIMEE'), "
-            + "(1, 3, 'MOIMEE'), "
-            + "(1, 4, 'MOIMEE'), "
-            + "(1, 5, 'MOIMEE')").executeUpdate();
+		entityManager.createNativeQuery("INSERT INTO CHAMYO (member_id, moim_id, moim_role, last_read_chat_id) VALUES "
+			+ "(1, 1, 'MOIMEE', 0), "
+			+ "(1, 2, 'MOIMEE', 0), "
+			+ "(1, 3, 'MOIMEE', 0), "
+			+ "(1, 4, 'MOIMEE', 0), "
+			+ "(1, 5, 'MOIMEE', 0)").executeUpdate();
 
-        entityManager.createNativeQuery("INSERT INTO ZZIM (member_id, moim_id) VALUES "
-            + "(1, 1), "
-            + "(1, 3), "
-            + "(1, 5)").executeUpdate();
+		entityManager.createNativeQuery("INSERT INTO ZZIM (member_id, moim_id) VALUES "
+			+ "(1, 1), "
+			+ "(1, 3), "
+			+ "(1, 5)").executeUpdate();
 
-        entityManager.clear();
-    }
+		entityManager.clear();
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

- 채팅방 목록 미리보기 api 구현
- 마지막으로 읽은 채팅 필드 추가

## 이슈 ID는 무엇인가요?

- #241 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

<img width="759" alt="image" src="https://github.com/user-attachments/assets/eea768a5-3e08-4d09-a461-ec5a328d1557">

채팅방 목록 미리보기을 위한 api 구현

이 api를 폴링하여 채팅방 미리보기를 렌더링합니다.

마지막으로 읽은 채팅에 대한 값을 참여 테이블에 넣었습니다.
이를 이용하여 읽지 않은 메세지의 개수를 카운트합니다.



## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
