### PR TITLE
관심 상태 변경시 해주세요 목록 전체에 관심 상태 표기가 변경되는 오류 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/please/service/InterestService.java
+++ b/backend/src/main/java/mouda/backend/please/service/InterestService.java
@@ -46,5 +46,4 @@ public class InterestService {
 		interestRepository.findByMemberIdAndPleaseId(member.getId(), pleaseId)
 			.ifPresent(interestRepository::delete);
 	}
-
 }

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -48,7 +48,8 @@ public class PleaseService {
 		return new PleaseFindAllResponses(
 			pleases.stream()
 				.map(please -> {
-					boolean isInterested = interestRepository.existsByMemberId(member.getId());
+					boolean isInterested = interestRepository
+						.existsByMemberIdAndPleaseId(member.getId(), please.getId());
 					long interestCount = interestRepository.countByPleaseId(please.getId());
 					return PleaseFindAllResponse.toResponse(please, isInterested, interestCount);
 				})

--- a/backend/src/test/java/mouda/backend/please/controller/InterestControllerTest.java
+++ b/backend/src/test/java/mouda/backend/please/controller/InterestControllerTest.java
@@ -43,7 +43,9 @@ public class InterestControllerTest {
 		RestAssured.port = port;
 
 		Please please = PleaseFixture.getPleaseWithAuthorId1L();
+		Please please2 = PleaseFixture.getPlease();
 		pleaseRepository.save(please);
+		pleaseRepository.save(please2);
 	}
 
 	@DisplayName("관심있어요 상태를 변경한다. -> 관심있어요.")
@@ -65,8 +67,10 @@ public class InterestControllerTest {
 			.all()
 			.statusCode(200);
 
-		Optional<Interest> byMemberIdAndPleaseId = interestRepository.findByMemberIdAndPleaseId(1L, 1L);
-		assertThat(byMemberIdAndPleaseId.isPresent()).isTrue();
+		Optional<Interest> interest = interestRepository.findByMemberIdAndPleaseId(1L, 1L);
+		Optional<Interest> interest2 = interestRepository.findByMemberIdAndPleaseId(1L, 2L);
+		assertThat(interest.isPresent()).isTrue();
+		assertThat(interest2.isPresent()).isFalse();
 	}
 
 	@DisplayName("관심있어요 상태를 변경한다. -> 관심있어요 취소.")

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -19,7 +19,9 @@ import mouda.backend.fixture.PleaseFixture;
 import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
 import mouda.backend.please.domain.Please;
+import mouda.backend.please.dto.request.InterestUpdateRequest;
 import mouda.backend.please.dto.request.PleaseCreateRequest;
+import mouda.backend.please.dto.response.PleaseFindAllResponses;
 import mouda.backend.please.exception.PleaseException;
 import mouda.backend.please.repository.PleaseRepository;
 
@@ -34,6 +36,9 @@ class PleaseServiceTest {
 
 	@Autowired
 	private PleaseService pleaseService;
+
+	@Autowired
+	private InterestService interestService;
 
 	@Autowired
 	private DatabaseCleaner databaseCleaner;
@@ -115,6 +120,23 @@ class PleaseServiceTest {
 
 			assertThatThrownBy(() -> pleaseService.deletePlease(tebah, 0L))
 				.isInstanceOf(PleaseException.class);
+		}
+
+		@DisplayName("관심있어요 상태 변경시 변경한 해주세요만 관심여부가 변경된다.")
+		@Test
+		void findAllPlease() {
+			Member tebah = memberRepository.save(MemberFixture.getTebah());
+			PleaseCreateRequest pleaseCreateRequest = new PleaseCreateRequest("치킨 사주세요", "제발요");
+			PleaseCreateRequest pleaseCreateRequest2 = new PleaseCreateRequest("치킨 사줄까요", "제발요요");
+			Please please = pleaseService.createPlease(tebah, pleaseCreateRequest);
+			pleaseService.createPlease(tebah, pleaseCreateRequest2);
+
+			InterestUpdateRequest interestUpdateRequest = new InterestUpdateRequest(please.getId(), true);
+			interestService.updateInterest(tebah, interestUpdateRequest);
+
+			PleaseFindAllResponses pleaseFindAllResponses = pleaseService.findAllPlease(tebah);
+			assertThat(pleaseFindAllResponses.pleases().get(0).isInterested()).isTrue();
+			assertThat(pleaseFindAllResponses.pleases().get(1).isInterested()).isFalse();
 		}
 	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
관심 상태 변경시 해주세요 목록 전체에 관심 상태 표기가 변경되는 오류 수정

## 이슈 ID는 무엇인가요?

- closed #253 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->
- [x] 관심 상태 변경시 해주세요 목록 전체에 관심 상태 표기가 변경되는 오류 수정

관심 여부를 해주세요 별로 조회할 때 memberId 로만 조회한게 원인
관심 여부 조회를 memberId와 pleaseId로 할 수 있도록 변경
  


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
