### PR TITLE
홈, 해주세요 목록 / 하단 네비게이션 바 UI 수정

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,4 +2,5 @@ node_modules
 dist
 *storybook.log
 .env
+.env*
 coverage

--- a/frontend/src/components/NavigationBarItem/NavigationBarItem.style.ts
+++ b/frontend/src/components/NavigationBarItem/NavigationBarItem.style.ts
@@ -7,7 +7,6 @@ export const navigationBarItem = (props: {
   const { theme, isActive } = props;
 
   return css`
-    ${theme.typography.c2}
     display: flex;
     flex: 1;
     flex-direction: column;

--- a/frontend/src/components/NavigationBarItem/NavigationBarItem.tsx
+++ b/frontend/src/components/NavigationBarItem/NavigationBarItem.tsx
@@ -34,7 +34,7 @@ export default function NavigationBarItem(props: NavigationBarItemProps) {
       onClick={() => onClick(tab)}
     >
       {tabIcon}
-      <span>{tab}</span>
+      <span css={theme.typography.c2}>{tab}</span>
     </li>
   );
 }

--- a/frontend/src/components/PlusButton/PlusButton.style.ts
+++ b/frontend/src/components/PlusButton/PlusButton.style.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+export const plusButton = css`
+  width: 68px;
+  height: 68px;
+  padding: 0;
+
+  background-color: white;
+  border: none;
+  border-radius: 50%;
+  box-shadow: 0 0 12.6px 0 rgb(178 178 178 / 33%);
+`;

--- a/frontend/src/components/PlusButton/PlusButton.tsx
+++ b/frontend/src/components/PlusButton/PlusButton.tsx
@@ -1,0 +1,16 @@
+import PlusIcon from '@_components/Icons/PlusIcon';
+import * as S from './PlusButton.style';
+
+interface PlusButtonProps {
+  onClick: () => void;
+}
+
+export default function PlusButton(props: PlusButtonProps) {
+  const { onClick } = props;
+
+  return (
+    <button onClick={onClick} css={S.plusButton}>
+      <PlusIcon />
+    </button>
+  );
+}

--- a/frontend/src/layouts/HomeLayout.tsx/HomeFixedButtonWrapper/HomeFixedButtonWrapper.style.ts
+++ b/frontend/src/layouts/HomeLayout.tsx/HomeFixedButtonWrapper/HomeFixedButtonWrapper.style.ts
@@ -11,5 +11,5 @@ export const fixedWrapperStyle = css`
   width: 100%;
   max-width: ${DISPLAY_MAX_WIDTH};
   margin-bottom: ${NAVIGATION_BAR_HEIGHT};
-  padding-right: 4rem;
+  padding-right: 24px;
 `;

--- a/frontend/src/layouts/HomeLayout.tsx/HomeLayout.style.ts
+++ b/frontend/src/layouts/HomeLayout.tsx/HomeLayout.style.ts
@@ -2,7 +2,7 @@ import { NAVIGATION_BAR_HEIGHT } from '@_constants/styles';
 import { css, Theme } from '@emotion/react';
 
 export const containerStyle = ({ theme }: { theme: Theme }) => css`
-  min-height: 100vh;
+  min-height: calc(100vh - ${NAVIGATION_BAR_HEIGHT} - 5.6rem);
   margin-top: 9.6rem;
   margin-bottom: ${NAVIGATION_BAR_HEIGHT};
   background-color: ${theme.colorPalette.grey[100]};

--- a/frontend/src/layouts/PleaseLayout/PleaseFixedButtonWrapper/PleaseFixedButtonWrapper.style.ts
+++ b/frontend/src/layouts/PleaseLayout/PleaseFixedButtonWrapper/PleaseFixedButtonWrapper.style.ts
@@ -11,5 +11,5 @@ export const fixedWrapperStyle = css`
   width: 100%;
   max-width: ${DISPLAY_MAX_WIDTH};
   margin-bottom: ${NAVIGATION_BAR_HEIGHT};
-  padding-right: 4rem;
+  padding-right: 24px;
 `;

--- a/frontend/src/layouts/PleaseLayout/PleaseLayout.style.ts
+++ b/frontend/src/layouts/PleaseLayout/PleaseLayout.style.ts
@@ -2,7 +2,7 @@ import { NAVIGATION_BAR_HEIGHT } from '@_constants/styles';
 import { css, Theme } from '@emotion/react';
 
 export const containerStyle = ({ theme }: { theme: Theme }) => css`
-  min-height: 100vh;
+  min-height: calc(100vh - ${NAVIGATION_BAR_HEIGHT} - 5.6rem);
   margin-top: 5.6rem;
   margin-bottom: ${NAVIGATION_BAR_HEIGHT};
   background-color: ${theme.colorPalette.grey[100]};

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -1,14 +1,13 @@
 import { Fragment, useState } from 'react';
 import MoimTabBar, { MainPageTab } from '@_components/MoimTabBar/MoimTabBar';
-import Button from '@_components/Button/Button';
 import HomeLayout from '@_layouts/HomeLayout.tsx/HomeLayout';
 import HomeMainContent from '@_components/HomeMainContent/HomeMainContent';
 import NavigationBar from '@_components/NavigationBar/NavigationBar';
 import NavigationBarWrapper from '@_layouts/components/NavigationBarWrapper/NavigationBarWrapper';
-import PlusIcon from '@_components/Icons/PlusIcon';
 import ROUTES from '@_constants/routes';
 import { useNavigate } from 'react-router-dom';
 import HomeHeaderContent from '@_components/HomeHeaderContent/HomHeaderContent';
+import PlusButton from '@_components/PlusButton/PlusButton';
 
 export default function MainPage() {
   const navigate = useNavigate();
@@ -32,14 +31,7 @@ export default function MainPage() {
         </HomeLayout.Main>
 
         <HomeLayout.HomeFixedButtonWrapper>
-          <Button
-            shape="circle"
-            onClick={() => navigate(ROUTES.addMoim)}
-            disabled={false}
-            reversePrimary
-          >
-            <PlusIcon />
-          </Button>
+          <PlusButton onClick={() => navigate(ROUTES.addMoim)} />
         </HomeLayout.HomeFixedButtonWrapper>
       </HomeLayout>
 

--- a/frontend/src/pages/PleasePage/PleasePage.tsx
+++ b/frontend/src/pages/PleasePage/PleasePage.tsx
@@ -1,7 +1,6 @@
-import Button from '@_components/Button/Button';
-import PlusIcon from '@_components/Icons/PlusIcon';
 import NavigationBar from '@_components/NavigationBar/NavigationBar';
 import PleaseList from '@_components/PleaseList/PleaseList';
+import PlusButton from '@_components/PlusButton/PlusButton';
 import ROUTES from '@_constants/routes';
 import NavigationBarWrapper from '@_layouts/components/NavigationBarWrapper/NavigationBarWrapper';
 import PleaseLayout from '@_layouts/PleaseLayout/PleaseLayout';
@@ -21,13 +20,7 @@ export default function PleasePage() {
         </PleaseLayout.Main>
 
         <PleaseLayout.HomeFixedButtonWrapper>
-          <Button
-            shape="circle"
-            onClick={() => navigate(ROUTES.please)}
-            disabled={false}
-          >
-            <PlusIcon />
-          </Button>
+          <PlusButton onClick={() => navigate(ROUTES.please)} />
         </PleaseLayout.HomeFixedButtonWrapper>
       </PleaseLayout>
       <NavigationBarWrapper>


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
홈, 해주세요 목록 UI 수정
하단 네비게이션 바 UI 수정


## 이슈 ID는 무엇인가요?

- closed #269 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

1. 생성(+) 버튼 별도로 컴포넌트 분리했어요. 괜히 버튼 컴포넌트의 복잡성을 높이는 것 같아요. 하단에 깔리는 Bar 형태의 버튼과는 성격이 다른 듯 합니다!
2. 생성 버튼의 width와 height를 일치하도록 적용했습니다.
3. 홈, 해주세요 목록 페이지에서 화면이 늘어나는 문제를 해결했어요. height가 100vh인데 margin top과 margin bottom이 있어서 영역이 늘어난 듯 합니다. calc를 활용해 margin 만큼을 뺐어요!
4. 하단 네비게이션 바의 typography가 씹히는 걸 발견하고 수정했습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
