### PR TITLE
날짜, 시간 모두 있는 경우만 유효성 검사

### DIFF
--- a/backend/src/main/java/mouda/backend/moim/domain/Moim.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Moim.java
@@ -89,20 +89,8 @@ public class Moim {
 		}
 	}
 
-	private void validateDate(LocalDate date) {
-		if (date == null) {
-			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.DATE_NOT_EXIST);
-		}
-	}
-
-	private void validateTime(LocalTime time) {
-		if (time == null) {
-			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.TIME_NOT_EXIST);
-		}
-	}
-
 	private void validateMoimIsFuture(LocalDate date, LocalTime time) {
-		if (date == null && time == null) {
+		if (date == null || time == null) {
 			return;
 		}
 		LocalDateTime moimDateTime = LocalDateTime.of(date, time);


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

날짜, 시간 중 하나라도 있는 경우 LocalDateTime으로 만들어 유효성 검사를 진행해 NPE 가 발생합니다. 이를 해결하기 위해 날짜, 시간이 모두 null이 아닌 경우 유효성 검사를 진행하도록 수정합니다.

## 이슈 ID는 무엇인가요?

- #301 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
