### PR TITLE
다락방 생성 및 내 다락방 조회 기능 추가

### DIFF
--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -1,0 +1,34 @@
+package mouda.backend.darakbang.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.common.RestResponse;
+import mouda.backend.config.argumentresolver.LoginMember;
+import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.service.DarakbangService;
+import mouda.backend.member.domain.Member;
+
+@RestController
+@RequestMapping("/v1/darakbang")
+@RequiredArgsConstructor
+public class DarakbangController implements DarakbangSwagger {
+
+	private final DarakbangService darakbangService;
+
+	@Override
+	@PostMapping
+	public ResponseEntity<RestResponse<Long>> createDarakbang(
+		@RequestBody DarakbangCreateRequest darakbangCreateRequest,
+		@LoginMember Member member
+	) {
+		Darakbang darakbang = darakbangService.createDarakbang(darakbangCreateRequest, member);
+		
+		return ResponseEntity.ok(new RestResponse<>(darakbang.getId()));
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -1,6 +1,7 @@
 package mouda.backend.darakbang.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.service.DarakbangService;
 import mouda.backend.member.domain.Member;
 
@@ -31,5 +33,11 @@ public class DarakbangController implements DarakbangSwagger {
 		Darakbang darakbang = darakbangService.createDarakbang(darakbangCreateRequest, member);
 
 		return ResponseEntity.ok(new RestResponse<>(darakbang.getId()));
+	}
+
+	@Override
+	@GetMapping("/mine")
+	public ResponseEntity<RestResponse<DarakbangResponses>> findAllMyDarakbangs(@LoginMember Member member) {
+		return null;
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -38,6 +38,8 @@ public class DarakbangController implements DarakbangSwagger {
 	@Override
 	@GetMapping("/mine")
 	public ResponseEntity<RestResponse<DarakbangResponses>> findAllMyDarakbangs(@LoginMember Member member) {
-		return null;
+		DarakbangResponses darakbangResponses = darakbangService.findAllMyDarakbangs(member);
+
+		return ResponseEntity.ok(new RestResponse<>(darakbangResponses));
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
@@ -24,11 +25,11 @@ public class DarakbangController implements DarakbangSwagger {
 	@Override
 	@PostMapping
 	public ResponseEntity<RestResponse<Long>> createDarakbang(
-		@RequestBody DarakbangCreateRequest darakbangCreateRequest,
+		@Valid @RequestBody DarakbangCreateRequest darakbangCreateRequest,
 		@LoginMember Member member
 	) {
 		Darakbang darakbang = darakbangService.createDarakbang(darakbangCreateRequest, member);
-		
+
 		return ResponseEntity.ok(new RestResponse<>(darakbang.getId()));
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.member.domain.Member;
 
 public interface DarakbangSwagger {
@@ -20,6 +21,14 @@ public interface DarakbangSwagger {
 	})
 	ResponseEntity<RestResponse<Long>> createDarakbang(
 		@RequestBody DarakbangCreateRequest darakbangCreateRequest,
+		@LoginMember Member member
+	);
+
+	@Operation(summary = "다락방 목록 조회", description = "참여한 다락방 목록을 조회한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "다락방 목록 조회 성공!")
+	})
+	ResponseEntity<RestResponse<DarakbangResponses>> findAllMyDarakbangs(
 		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -1,0 +1,25 @@
+package mouda.backend.darakbang.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import mouda.backend.common.RestResponse;
+import mouda.backend.config.argumentresolver.LoginMember;
+import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.member.domain.Member;
+
+public interface DarakbangSwagger {
+
+	@Operation(summary = "다락방 생성", description = "다락방을 생성한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "다락방 생성 성공!"),
+		@ApiResponse(responseCode = "400", description = "이미 존재하는 다락방 이름입니다.")
+	})
+	ResponseEntity<RestResponse<Long>> createDarakbang(
+		@RequestBody DarakbangCreateRequest darakbangCreateRequest,
+		@LoginMember Member member
+	);
+}

--- a/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
+++ b/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
@@ -25,7 +25,7 @@ public class Darakbang {
 	@Column(nullable = false)
 	private String name;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String code;
 
 	@Builder

--- a/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
+++ b/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
@@ -1,0 +1,32 @@
+package mouda.backend.darakbang.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Darakbang {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private String code;
+
+	@Builder
+	public Darakbang(String name, String code) {
+		this.name = name;
+		this.code = code;
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
+++ b/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
@@ -1,5 +1,7 @@
 package mouda.backend.darakbang.domain;
 
+import org.springframework.http.HttpStatus;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -8,6 +10,8 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.darakbang.exception.DarakbangErrorMessage;
+import mouda.backend.darakbang.exception.DarakbangException;
 
 @Entity
 @Getter
@@ -26,7 +30,14 @@ public class Darakbang {
 
 	@Builder
 	public Darakbang(String name, String code) {
+		validateName(name);
 		this.name = name;
 		this.code = code;
+	}
+
+	private void validateName(String name) {
+		if (name == null || name.isBlank()) {
+			throw new DarakbangException(HttpStatus.BAD_REQUEST, DarakbangErrorMessage.NAME_NOT_EXIST);
+		}
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangCreateRequest.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangCreateRequest.java
@@ -1,0 +1,19 @@
+package mouda.backend.darakbang.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import mouda.backend.darakbang.domain.Darakbang;
+
+public record DarakbangCreateRequest(
+	@NotNull
+	String name,
+
+	@NotNull
+	String nickname
+) {
+	public Darakbang toEntity(String code) {
+		return Darakbang.builder()
+			.name(name)
+			.code(code)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponse.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponse.java
@@ -1,0 +1,18 @@
+package mouda.backend.darakbang.dto.response;
+
+import lombok.Builder;
+import mouda.backend.darakbang.domain.Darakbang;
+
+@Builder
+public record DarakbangResponse(
+	long darakbangId,
+	String name
+) {
+	
+	public static DarakbangResponse toResponse(Darakbang darakbang) {
+		return DarakbangResponse.builder()
+			.darakbangId(darakbang.getId())
+			.name(darakbang.getName())
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponse.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponse.java
@@ -1,18 +1,18 @@
 package mouda.backend.darakbang.dto.response;
 
 import lombok.Builder;
-import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Builder
 public record DarakbangResponse(
 	long darakbangId,
 	String name
 ) {
-	
-	public static DarakbangResponse toResponse(Darakbang darakbang) {
+
+	public static DarakbangResponse toResponse(DarakbangMember darakbangMember) {
 		return DarakbangResponse.builder()
-			.darakbangId(darakbang.getId())
-			.name(darakbang.getName())
+			.darakbangId(darakbangMember.getId())
+			.name(darakbangMember.getDarakbangName())
 			.build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponses.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/DarakbangResponses.java
@@ -1,0 +1,17 @@
+package mouda.backend.darakbang.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record DarakbangResponses(
+	List<DarakbangResponse> darakbangResponses
+) {
+	
+	public static DarakbangResponses toResponse(List<DarakbangResponse> responses) {
+		return DarakbangResponses.builder()
+			.darakbangResponses(responses)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
@@ -10,7 +10,7 @@ public enum DarakbangErrorMessage {
 	NAME_ALREADY_EXIST("이미 존재하는 다락방 이름입니다."),
 	NAME_NOT_EXIST("다락방 이름이 존재하지 않습니다."),
 	CODE_NOT_EXIST("다락방 초대 코드가 존재하지 않습니다."),
-	;
+	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다");
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
@@ -1,0 +1,16 @@
+package mouda.backend.darakbang.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DarakbangErrorMessage {
+
+	NAME_ALREADY_EXIST("이미 존재하는 다락방 이름입니다."),
+	NAME_NOT_EXIST("다락방 이름이 존재하지 않습니다."),
+	CODE_NOT_EXIST("다락방 초대 코드가 존재하지 않습니다."),
+	;
+
+	private final String message;
+}

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangException.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangException.java
@@ -1,0 +1,12 @@
+package mouda.backend.darakbang.exception;
+
+import org.springframework.http.HttpStatus;
+
+import mouda.backend.exception.MoudaException;
+
+public class DarakbangException extends MoudaException {
+
+	public DarakbangException(HttpStatus httpStatus, DarakbangErrorMessage message) {
+		super(httpStatus, message.getMessage());
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
@@ -7,4 +7,6 @@ import mouda.backend.darakbang.domain.Darakbang;
 
 @Repository
 public interface DarakbangRepository extends JpaRepository<Darakbang, Long> {
+
+	boolean existsByName(String name);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
@@ -9,4 +9,6 @@ import mouda.backend.darakbang.domain.Darakbang;
 public interface DarakbangRepository extends JpaRepository<Darakbang, Long> {
 
 	boolean existsByName(String name);
+
+	boolean existsByCode(String code);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
@@ -1,0 +1,10 @@
+package mouda.backend.darakbang.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import mouda.backend.darakbang.domain.Darakbang;
+
+@Repository
+public interface DarakbangRepository extends JpaRepository<Darakbang, Long> {
+}

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -1,5 +1,7 @@
 package mouda.backend.darakbang.service;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.DarakbangResponse;
+import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.exception.DarakbangErrorMessage;
 import mouda.backend.darakbang.exception.DarakbangException;
 import mouda.backend.darakbang.repository.DarakbangRepository;
@@ -30,15 +34,26 @@ public class DarakbangService {
 		}
 
 		String invitationCode = invitationCodeGenerator.generate();
-		Darakbang darakbang = darakbangCreateRequest.toEntity(invitationCode);
+		Darakbang entity = darakbangCreateRequest.toEntity(invitationCode);
+		Darakbang darakbang = darakbangRepository.save(entity);
 
 		DarakbangMember darakbangMember = DarakbangMember.builder()
+			.darakbang(darakbang)
 			.member(member)
 			.nickname(darakbangCreateRequest.nickname())
 			.role(DarakBangMemberRole.MANAGER)
 			.build();
 		darakbangMemberRepository.save(darakbangMember);
 
-		return darakbangRepository.save(darakbang);
+		return darakbang;
+	}
+
+	public DarakbangResponses findAllMyDarakbangs(Member member) {
+		List<DarakbangMember> darakbangMembers = darakbangMemberRepository.findAllByMemberId(member.getId());
+		List<DarakbangResponse> responses = darakbangMembers.stream()
+			.map(DarakbangResponse::toResponse)
+			.toList();
+
+		return DarakbangResponses.toResponse(responses);
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -33,7 +33,7 @@ public class DarakbangService {
 			throw new DarakbangException(HttpStatus.BAD_REQUEST, DarakbangErrorMessage.NAME_ALREADY_EXIST);
 		}
 
-		String invitationCode = invitationCodeGenerator.generate();
+		String invitationCode = generateInvitationCode();
 		Darakbang entity = darakbangCreateRequest.toEntity(invitationCode);
 		Darakbang darakbang = darakbangRepository.save(entity);
 
@@ -46,6 +46,14 @@ public class DarakbangService {
 		darakbangMemberRepository.save(darakbangMember);
 
 		return darakbang;
+	}
+
+	private String generateInvitationCode() {
+		String invitationCode = invitationCodeGenerator.generate();
+		if (darakbangRepository.existsByCode(invitationCode)) {
+			throw new DarakbangException(HttpStatus.INTERNAL_SERVER_ERROR, DarakbangErrorMessage.CODE_ALREADY_EXIST);
+		}
+		return invitationCode;
 	}
 
 	public DarakbangResponses findAllMyDarakbangs(Member member) {

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -1,11 +1,14 @@
 package mouda.backend.darakbang.service;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.exception.DarakbangErrorMessage;
+import mouda.backend.darakbang.exception.DarakbangException;
 import mouda.backend.darakbang.repository.DarakbangRepository;
 import mouda.backend.darakbangmember.domain.DarakBangMemberRole;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
@@ -22,6 +25,10 @@ public class DarakbangService {
 	private final InvitationCodeGenerator invitationCodeGenerator;
 
 	public Darakbang createDarakbang(DarakbangCreateRequest darakbangCreateRequest, Member member) {
+		if (darakbangRepository.existsByName(darakbangCreateRequest.name())) {
+			throw new DarakbangException(HttpStatus.BAD_REQUEST, DarakbangErrorMessage.NAME_ALREADY_EXIST);
+		}
+
 		String invitationCode = invitationCodeGenerator.generate();
 		Darakbang darakbang = darakbangCreateRequest.toEntity(invitationCode);
 

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -1,0 +1,37 @@
+package mouda.backend.darakbang.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.repository.DarakbangRepository;
+import mouda.backend.darakbangmember.domain.DarakBangMemberRole;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.member.domain.Member;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DarakbangService {
+
+	private final DarakbangRepository darakbangRepository;
+	private final DarakbangMemberRepository darakbangMemberRepository;
+	private final InvitationCodeGenerator invitationCodeGenerator;
+
+	public Darakbang createDarakbang(DarakbangCreateRequest darakbangCreateRequest, Member member) {
+		String invitationCode = invitationCodeGenerator.generate();
+		Darakbang darakbang = darakbangCreateRequest.toEntity(invitationCode);
+
+		DarakbangMember darakbangMember = DarakbangMember.builder()
+			.member(member)
+			.nickname(darakbangCreateRequest.nickname())
+			.role(DarakBangMemberRole.MANAGER)
+			.build();
+		darakbangMemberRepository.save(darakbangMember);
+
+		return darakbangRepository.save(darakbang);
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/service/InvitationCodeGenerator.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/InvitationCodeGenerator.java
@@ -1,0 +1,33 @@
+package mouda.backend.darakbang.service;
+
+import java.security.SecureRandom;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class InvitationCodeGenerator {
+
+	private static final int CODE_LENGTH = 7;
+	private static final int NUMBER_UPPER_BOUND = 10;
+	private static final int CHAR_RANDOM_BOUND = 26;
+
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	public String generate() {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < CODE_LENGTH; i++) {
+			if (secureRandom.nextBoolean()) {
+				sb.append(secureRandom.nextInt(NUMBER_UPPER_BOUND));
+			} else {
+				sb.append(getRandomUpperAlphabet());
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private char getRandomUpperAlphabet() {
+		return (char)(secureRandom.nextInt(CHAR_RANDOM_BOUND) + 65);
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/service/InvitationCodeGenerator.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/InvitationCodeGenerator.java
@@ -14,17 +14,17 @@ public class InvitationCodeGenerator {
 	private final SecureRandom secureRandom = new SecureRandom();
 
 	public String generate() {
-		StringBuilder sb = new StringBuilder();
+		StringBuilder code = new StringBuilder();
 
 		for (int i = 0; i < CODE_LENGTH; i++) {
 			if (secureRandom.nextBoolean()) {
-				sb.append(secureRandom.nextInt(NUMBER_UPPER_BOUND));
+				code.append(secureRandom.nextInt(NUMBER_UPPER_BOUND));
 			} else {
-				sb.append(getRandomUpperAlphabet());
+				code.append(getRandomUpperAlphabet());
 			}
 		}
 
-		return sb.toString();
+		return code.toString();
 	}
 
 	private char getRandomUpperAlphabet() {

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakBangMemberRole.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakBangMemberRole.java
@@ -1,0 +1,10 @@
+package mouda.backend.darakbangmember.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum DarakBangMemberRole {
+	MANAGER,
+	MEMBER,
+	OUTSIDER
+}

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -1,0 +1,44 @@
+package mouda.backend.darakbangmember.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mouda.backend.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class DarakbangMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	@Column(nullable = false)
+	private String nickname;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private DarakBangMemberRole role;
+
+	@Builder
+	public DarakbangMember(Member member, String nickname, DarakBangMemberRole role) {
+		this.member = member;
+		this.nickname = nickname;
+		this.role = role;
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbangmember.exception.DarakbangMemberErrorMessage;
 import mouda.backend.darakbangmember.exception.DarakbangMemberException;
 import mouda.backend.member.domain.Member;
@@ -30,6 +31,10 @@ public class DarakbangMember {
 
 	@JoinColumn(nullable = false)
 	@ManyToOne(fetch = FetchType.LAZY)
+	private Darakbang darakbang;
+
+	@JoinColumn(nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Member member;
 
 	@Column(nullable = false)
@@ -40,8 +45,9 @@ public class DarakbangMember {
 	private DarakBangMemberRole role;
 
 	@Builder
-	public DarakbangMember(Member member, String nickname, DarakBangMemberRole role) {
+	public DarakbangMember(Darakbang darakbang, Member member, String nickname, DarakBangMemberRole role) {
 		validateNickname(nickname);
+		this.darakbang = darakbang;
 		this.member = member;
 		this.nickname = nickname;
 		this.role = role;
@@ -51,5 +57,9 @@ public class DarakbangMember {
 		if (nickname == null || nickname.isBlank()) {
 			throw new DarakbangMemberException(HttpStatus.BAD_REQUEST, DarakbangMemberErrorMessage.NICKNAME_NOT_EXIST);
 		}
+	}
+
+	public String getDarakbangName() {
+		return darakbang.getName();
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -1,5 +1,7 @@
 package mouda.backend.darakbangmember.domain;
 
+import org.springframework.http.HttpStatus;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +15,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.darakbangmember.exception.DarakbangMemberErrorMessage;
+import mouda.backend.darakbangmember.exception.DarakbangMemberException;
 import mouda.backend.member.domain.Member;
 
 @Entity
@@ -37,8 +41,15 @@ public class DarakbangMember {
 
 	@Builder
 	public DarakbangMember(Member member, String nickname, DarakBangMemberRole role) {
+		validateNickname(nickname);
 		this.member = member;
 		this.nickname = nickname;
 		this.role = role;
+	}
+
+	private void validateNickname(String nickname) {
+		if (nickname == null || nickname.isBlank()) {
+			throw new DarakbangMemberException(HttpStatus.BAD_REQUEST, DarakbangMemberErrorMessage.NICKNAME_NOT_EXIST);
+		}
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
@@ -1,0 +1,14 @@
+package mouda.backend.darakbangmember.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DarakbangMemberErrorMessage {
+
+	NICKNAME_NOT_EXIST("닉네임이 존재하지 않습니다."),
+	;
+
+	private final String message;
+}

--- a/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberException.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberException.java
@@ -1,0 +1,12 @@
+package mouda.backend.darakbangmember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import mouda.backend.exception.MoudaException;
+
+public class DarakbangMemberException extends MoudaException {
+
+	public DarakbangMemberException(HttpStatus httpStatus, DarakbangMemberErrorMessage message) {
+		super(httpStatus, message.getMessage());
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
@@ -1,5 +1,7 @@
 package mouda.backend.darakbangmember.repository.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Repository
 public interface DarakbangMemberRepository extends JpaRepository<DarakbangMember, Long> {
+
+	List<DarakbangMember> findAllByMemberId(long memberId);
 }

--- a/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
@@ -1,0 +1,10 @@
+package mouda.backend.darakbangmember.repository.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+
+@Repository
+public interface DarakbangMemberRepository extends JpaRepository<DarakbangMember, Long> {
+}

--- a/backend/src/test/java/mouda/backend/config/DatabaseCleaner.java
+++ b/backend/src/test/java/mouda/backend/config/DatabaseCleaner.java
@@ -36,11 +36,17 @@ public class DatabaseCleaner {
 		entityManager.createNativeQuery("DELETE FROM PLEASE").executeUpdate();
 		entityManager.createNativeQuery("ALTER TABLE PLEASE alter column id restart with 1").executeUpdate();
 
+		entityManager.createNativeQuery("DELETE FROM DARAKBANG_MEMBER").executeUpdate();
+		entityManager.createNativeQuery("ALTER TABLE DARAKBANG_MEMBER alter column id restart with 1").executeUpdate();
+
 		entityManager.createNativeQuery("DELETE FROM MEMBER").executeUpdate();
 		entityManager.createNativeQuery("ALTER TABLE MEMBER alter column id restart with 1").executeUpdate();
 
 		entityManager.createNativeQuery("DELETE FROM MOIM").executeUpdate();
 		entityManager.createNativeQuery("ALTER TABLE MOIM alter column id restart with 1").executeUpdate();
+
+		entityManager.createNativeQuery("DELETE FROM DARAKBANG").executeUpdate();
+		entityManager.createNativeQuery("ALTER TABLE DARAKBANG alter column id restart with 1").executeUpdate();
 
 		entityManager.clear();
 	}

--- a/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
@@ -94,5 +94,25 @@ class DarakbangServiceTest {
 			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
 				.isInstanceOf(DarakbangMemberException.class);
 		}
+
+		@DisplayName("초대코드가 중복되면 다락방 생성에 실패한다.")
+		@Test
+		void failToCreateDarakbangWithDuplicatedCode() {
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			DarakbangCreateRequest request = new DarakbangCreateRequest("우테코", "테니");
+			darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+
+			darakbangService = new DarakbangService(darakbangRepository, darakbangMemberRepository,
+				new InvitationCodeGenerator() {
+					@Override
+					public String generate() {
+						return "SOFABABO1";
+					}
+				});
+
+			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
+				.isInstanceOf(DarakbangException.class);
+		}
+
 	}
 }

--- a/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
@@ -1,0 +1,45 @@
+package mouda.backend.darakbang.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import mouda.backend.config.DatabaseCleaner;
+import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.fixture.MemberFixture;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+
+@SpringBootTest
+class DarakbangServiceTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private DarakbangService darakbangService;
+
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@AfterEach
+	void cleanUp() {
+		databaseCleaner.cleanUp();
+	}
+
+	@DisplayName("다락방 생성에 성공한다.")
+	@Test
+	void success() {
+		DarakbangCreateRequest request = new DarakbangCreateRequest("우아한테크코스", "테니");
+		Member hogee = memberRepository.save(MemberFixture.getHogee());
+
+		Darakbang darakbang = darakbangService.createDarakbang(request, hogee);
+
+		assertThat(darakbang.getId()).isEqualTo(1L);
+	}
+}

--- a/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
@@ -4,13 +4,21 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import mouda.backend.config.DatabaseCleaner;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.exception.DarakbangException;
+import mouda.backend.darakbang.repository.DarakbangRepository;
+import mouda.backend.darakbangmember.exception.DarakbangMemberException;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.fixture.DarakbangFixture;
 import mouda.backend.fixture.MemberFixture;
 import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
@@ -20,6 +28,12 @@ class DarakbangServiceTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private DarakbangRepository darakbangRepository;
+
+	@Autowired
+	private DarakbangMemberRepository darakbangMemberRepository;
 
 	@Autowired
 	private DarakbangService darakbangService;
@@ -32,14 +46,53 @@ class DarakbangServiceTest {
 		databaseCleaner.cleanUp();
 	}
 
-	@DisplayName("다락방 생성에 성공한다.")
-	@Test
-	void success() {
-		DarakbangCreateRequest request = new DarakbangCreateRequest("우아한테크코스", "테니");
-		Member hogee = memberRepository.save(MemberFixture.getHogee());
+	@DisplayName("다락방 생성 테스트")
+	@Nested
+	class DarakbangCreateTest {
 
-		Darakbang darakbang = darakbangService.createDarakbang(request, hogee);
+		@DisplayName("다락방을 성공적으로 생성한다.")
+		@Test
+		void success() {
+			DarakbangCreateRequest request = new DarakbangCreateRequest("우아한테크코스", "테니");
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
 
-		assertThat(darakbang.getId()).isEqualTo(1L);
+			Darakbang darakbang = darakbangService.createDarakbang(request, hogee);
+
+			assertThat(darakbang.getId()).isEqualTo(1L);
+			assertThat(darakbangMemberRepository.findAll()).hasSize(1);
+		}
+
+		@DisplayName("다락방 이름이 중복되면 생성에 실패한다.")
+		@Test
+		void failToCreateDarakbangWithDuplicatedName() {
+			darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			DarakbangCreateRequest request = new DarakbangCreateRequest("우아한테크코스", "테니");
+
+			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
+				.isInstanceOf(DarakbangException.class);
+		}
+
+		@DisplayName("다락방 이름이 존재하지 않으면 생성에 실패한다.")
+		@NullAndEmptySource
+		@ParameterizedTest
+		void failToCreateDarakbangWithoutName(String name) {
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			DarakbangCreateRequest request = new DarakbangCreateRequest(name, "테니");
+
+			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
+				.isInstanceOf(DarakbangException.class);
+		}
+
+		@DisplayName("닉네임이 존재하지 않으면 다락방 생성에 실패한다.")
+		@NullAndEmptySource
+		@ParameterizedTest
+		void failToCreateDarakbangWithoutNickname(String nickname) {
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			DarakbangCreateRequest request = new DarakbangCreateRequest("우아한테크코스", nickname);
+
+			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
+				.isInstanceOf(DarakbangMemberException.class);
+		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/darakbang/service/InvitationCodeGeneratorTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/InvitationCodeGeneratorTest.java
@@ -1,0 +1,24 @@
+package mouda.backend.darakbang.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class InvitationCodeGeneratorTest {
+
+	@Autowired
+	private
+	InvitationCodeGenerator invitationCodeGenerator;
+
+	@DisplayName("7자리 랜덤코드를 생성한다.")
+	@Test
+	void success() {
+		String invitationCode = invitationCodeGenerator.generate();
+		
+		assertThat(invitationCode).hasSize(7);
+	}
+}

--- a/backend/src/test/java/mouda/backend/fixture/DarakbangFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/DarakbangFixture.java
@@ -1,0 +1,13 @@
+package mouda.backend.fixture;
+
+import mouda.backend.darakbang.domain.Darakbang;
+
+public class DarakbangFixture {
+
+	public static Darakbang getDarakbangWithWooteco() {
+		return Darakbang.builder()
+			.name("우아한테크코스")
+			.code("SOFABABO1")
+			.build();
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

- 다락방을 생성합니다.
- 내가 참여한 다락방 목록을 조회합니다.

## 이슈 ID는 무엇인가요?

- #327 

## 설명

- 다락방 생성 시 랜덤 초대코드를 발급합니다.
- 초대코드는 0-9, A-Z로 이루어지며 길이 7인 문자열 입니다.
- SecureRandom이 Random에 비해 예측불가능하다는 이점이 있어 사용하였습니다. [[참고](https://www.baeldung.com/java-secure-random#comparisionWithRandom)]

## 질문 혹은 공유 사항 (Optional)
