### PR TITLE
모임어 상태에서 케밥 메뉴의 '모임 삭제하기'를 '모임 취소하기'로 변경, 하드 코딩된 타입 선언

### DIFF
--- a/frontend/src/apis/gets.ts
+++ b/frontend/src/apis/gets.ts
@@ -1,4 +1,10 @@
-import { Chat, ChattingPreview, MoimInfo, Participation } from '@_types/index';
+import {
+  Chat,
+  ChattingPreview,
+  MoimInfo,
+  Participation,
+  Role,
+} from '@_types/index';
 import {
   GetChamyoAll,
   GetChamyoMine,
@@ -70,9 +76,7 @@ export const getMyMoims = async (): Promise<MoimInfo[]> => {
   return json.data.moims;
 };
 
-export const getChamyoMine = async (
-  moimId: number,
-): Promise<'MOIMER' | 'MOIMEE' | 'NON_MOIMEE'> => {
+export const getChamyoMine = async (moimId: number): Promise<Role> => {
   const response = await ApiClient.getWithAuth(`chamyo/mine?moimId=${moimId}`);
 
   const json: GetChamyoMine = await response.json();

--- a/frontend/src/apis/responseTypes.ts
+++ b/frontend/src/apis/responseTypes.ts
@@ -4,6 +4,7 @@ import {
   MoimInfo,
   Participation,
   Please,
+  Role,
 } from '../types';
 
 export interface GetMoims {
@@ -35,7 +36,7 @@ export interface GetChat {
 
 export interface GetChamyoMine {
   data: {
-    role: 'MOIMER' | 'MOIMEE' | 'NON_MOIMEE';
+    role: Role;
   };
 }
 

--- a/frontend/src/components/Tag/Tag.style.ts
+++ b/frontend/src/components/Tag/Tag.style.ts
@@ -1,8 +1,9 @@
+import { MoimStatus } from '@_types/index';
 import { css, Theme } from '@emotion/react';
 
 interface TagBoxProps {
   theme: Theme;
-  status: 'MOIMING' | 'COMPLETED' | 'CANCELED';
+  status: MoimStatus;
 }
 export const tagBox = (props: TagBoxProps) => {
   const { theme, status } = props;

--- a/frontend/src/components/Tag/Tag.tsx
+++ b/frontend/src/components/Tag/Tag.tsx
@@ -2,9 +2,10 @@ import * as S from '@_components/Tag/Tag.style';
 
 import { HTMLProps } from 'react';
 import { useTheme } from '@emotion/react';
+import { MoimStatus } from '@_types/index';
 
 interface TagProps extends HTMLProps<HTMLDivElement> {
-  status: 'MOIMING' | 'COMPLETED' | 'CANCELED';
+  status: MoimStatus;
 }
 
 export default function Tag(props: TagProps) {

--- a/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
+++ b/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
@@ -81,7 +81,7 @@ export default function MoimDetailPage() {
                       },
                     }),
                 },
-                { name: '모임 삭제하기', onClick: () => cancelMoim(moimId) },
+                { name: '모임 취소하기', onClick: () => cancelMoim(moimId) },
                 { name: '모임 다시 열기', onClick: () => ReopenMoim(moimId) },
               ]}
             />

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -13,7 +13,7 @@ export interface MoimInfo {
   authorNickname: string;
   participants: Participation[];
   description?: string;
-  status: 'MOIMING' | 'COMPLETED' | 'CANCELED';
+  status: MoimStatus;
   comments: Comment[];
   isZzimed: boolean;
 }
@@ -24,6 +24,7 @@ export interface Participation {
   role: Role;
 }
 
+export type MoimStatus = 'MOIMING' | 'COMPLETED' | 'CANCELED';
 export type Role = 'MOIMER' | 'MOIMEE' | 'NON_MOIMEE';
 
 export interface Comment {


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

모임어 상태에서 케밥 메뉴의 '모임 삭제하기'를 '모임 취소하기'로 변경, 하드 코딩된 타입 선언

## 이슈 ID는 무엇인가요?

- #337

## 설명

케밥 메뉴의 모임 삭제하기를 도메인 이름에 맞게 모임 취소하기로 변경하였습니다.
또한 하드 코딩된 
'MOIMING' | 'COMPLETED' | 'CANCELED'
'MOIMER' | 'MOIMEE' | 'NON_MOIMEE'
을 타입 선언 해주었습니다.
## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
