### PR TITLE
초대코드 조회, 초대코드 유효성 검사, 다락방 참여 기능

### DIFF
--- a/.github/workflows/cicd-backend-dev.yml
+++ b/.github/workflows/cicd-backend-dev.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Firebase 파일 이동
         run: |
+          mkdir -p src/main/resources/firebase
           echo ${{ secrets.BACKEND_FIREBASE_JSON }} > src/main/resources/firebase/serviceAccountKey.json
 
       - name: gradlew 권한 부여

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,3 +6,4 @@ build/
 .idea
 out
 logs
+src/main/resources/firebase

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -51,6 +51,8 @@ public class DarakbangController implements DarakbangSwagger {
 		@PathVariable Long darakbangId,
 		@LoginMember Member member
 	) {
-		return null;
+		InvitationCodeResponse invitationCodeResponse = darakbangService.findInvitationCode(darakbangId, member);
+
+		return ResponseEntity.ok(new RestResponse<>(invitationCodeResponse));
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -60,10 +60,9 @@ public class DarakbangController implements DarakbangSwagger {
 
 	@Override
 	@GetMapping("/validation")
-	public ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
-		@RequestParam String code,
-		@LoginMember Member member
-	) {
-		return null;
+	public ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(@RequestParam String code) {
+		CodeValidationResponse codeValidationResponse = darakbangService.validateCode(code);
+
+		return ResponseEntity.ok(new RestResponse<>(codeValidationResponse));
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -15,6 +15,7 @@ import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.request.DarakbangJoinRequest;
 import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
@@ -64,5 +65,15 @@ public class DarakbangController implements DarakbangSwagger {
 		CodeValidationResponse codeValidationResponse = darakbangService.validateCode(code);
 
 		return ResponseEntity.ok(new RestResponse<>(codeValidationResponse));
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<RestResponse<Long>> joinDarakbang(
+		@RequestParam String code,
+		@RequestBody DarakbangJoinRequest darakbangJoinRequest,
+		@LoginMember Member member
+	) {
+		return null;
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
 import mouda.backend.darakbang.service.DarakbangService;
@@ -54,5 +56,14 @@ public class DarakbangController implements DarakbangSwagger {
 		InvitationCodeResponse invitationCodeResponse = darakbangService.findInvitationCode(darakbangId, member);
 
 		return ResponseEntity.ok(new RestResponse<>(invitationCodeResponse));
+	}
+
+	@Override
+	@GetMapping("/validation")
+	public ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
+		@RequestParam String code,
+		@LoginMember Member member
+	) {
+		return null;
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -15,7 +15,7 @@ import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
-import mouda.backend.darakbang.dto.request.DarakbangJoinRequest;
+import mouda.backend.darakbang.dto.request.DarakbangEnterRequest;
 import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
@@ -68,12 +68,14 @@ public class DarakbangController implements DarakbangSwagger {
 	}
 
 	@Override
-	@PostMapping
-	public ResponseEntity<RestResponse<Long>> joinDarakbang(
+	@PostMapping("/entrance")
+	public ResponseEntity<RestResponse<Long>> enterDarakbang(
 		@RequestParam String code,
-		@RequestBody DarakbangJoinRequest darakbangJoinRequest,
+		@RequestBody DarakbangEnterRequest darakbangEnterRequest,
 		@LoginMember Member member
 	) {
-		return null;
+		Darakbang darakbang = darakbangService.enter(code, darakbangEnterRequest, member);
+
+		return ResponseEntity.ok(new RestResponse<>(darakbang.getId()));
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangController.java
@@ -2,6 +2,7 @@ package mouda.backend.darakbang.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
+import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
 import mouda.backend.darakbang.service.DarakbangService;
 import mouda.backend.member.domain.Member;
 
@@ -41,5 +43,14 @@ public class DarakbangController implements DarakbangSwagger {
 		DarakbangResponses darakbangResponses = darakbangService.findAllMyDarakbangs(member);
 
 		return ResponseEntity.ok(new RestResponse<>(darakbangResponses));
+	}
+
+	@Override
+	@GetMapping("/{darakbangId}/code")
+	public ResponseEntity<RestResponse<InvitationCodeResponse>> findInvitationCode(
+		@PathVariable Long darakbangId,
+		@LoginMember Member member
+	) {
+		return null;
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -53,7 +53,6 @@ public interface DarakbangSwagger {
 		@ApiResponse(responseCode = "200", description = "다락방 초대코드 유효성 검사 성공!")
 	})
 	ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
-		@RequestParam String code,
-		@LoginMember Member member
+		@RequestParam String code
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -51,7 +51,8 @@ public interface DarakbangSwagger {
 
 	@Operation(summary = "다락방 초대코드 유효성 검사", description = "다락방 초대코드 유효성을 검사한다.")
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "다락방 초대코드 유효성 검사 성공!")
+		@ApiResponse(responseCode = "200", description = "다락방 초대코드 유효성 검사 성공!"),
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 초대코드입니다.")
 	})
 	ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
 		@RequestParam String code
@@ -59,7 +60,10 @@ public interface DarakbangSwagger {
 
 	@Operation(summary = "다락방 참여", description = "다락방에 참여한다.")
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "다락방 참여 성공!")
+		@ApiResponse(responseCode = "200", description = "다락방 참여 성공!"),
+		@ApiResponse(responseCode = "400", description = "이미 존재하는 닉네임입니다."),
+		@ApiResponse(responseCode = "400", description = "이미 가입한 멤버입니다."),
+		@ApiResponse(responseCode = "404", description = "다락방이 존재하지 않습니다."),
 	})
 	ResponseEntity<RestResponse<Long>> enterDarakbang(
 		@RequestParam String code,

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
-import mouda.backend.darakbang.dto.request.DarakbangJoinRequest;
+import mouda.backend.darakbang.dto.request.DarakbangEnterRequest;
 import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
@@ -61,9 +61,9 @@ public interface DarakbangSwagger {
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "다락방 참여 성공!")
 	})
-	ResponseEntity<RestResponse<Long>> joinDarakbang(
+	ResponseEntity<RestResponse<Long>> enterDarakbang(
 		@RequestParam String code,
-		@RequestBody DarakbangJoinRequest darakbangJoinRequest,
+		@RequestBody DarakbangEnterRequest darakbangEnterRequest,
 		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.request.DarakbangJoinRequest;
 import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
@@ -54,5 +55,15 @@ public interface DarakbangSwagger {
 	})
 	ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
 		@RequestParam String code
+	);
+
+	@Operation(summary = "다락방 참여", description = "다락방에 참여한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "다락방 참여 성공!")
+	})
+	ResponseEntity<RestResponse<Long>> joinDarakbang(
+		@RequestParam String code,
+		@RequestBody DarakbangJoinRequest darakbangJoinRequest,
+		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -3,6 +3,7 @@ package mouda.backend.darakbang.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
 import mouda.backend.member.domain.Member;
@@ -43,6 +45,15 @@ public interface DarakbangSwagger {
 	})
 	ResponseEntity<RestResponse<InvitationCodeResponse>> findInvitationCode(
 		@PathVariable Long darakbangId,
+		@LoginMember Member member
+	);
+
+	@Operation(summary = "다락방 초대코드 유효성 검사", description = "다락방 초대코드 유효성을 검사한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "다락방 초대코드 유효성 검사 성공!")
+	})
+	ResponseEntity<RestResponse<CodeValidationResponse>> validateInvitationCode(
+		@RequestParam String code,
 		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -1,6 +1,7 @@
 package mouda.backend.darakbang.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
+import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
 import mouda.backend.member.domain.Member;
 
 public interface DarakbangSwagger {
@@ -29,6 +31,16 @@ public interface DarakbangSwagger {
 		@ApiResponse(responseCode = "200", description = "다락방 목록 조회 성공!")
 	})
 	ResponseEntity<RestResponse<DarakbangResponses>> findAllMyDarakbangs(
+		@LoginMember Member member
+	);
+
+	@Operation(summary = "다락방 참여코드 조회", description = "참여한 다락방 참여코드를 조회한다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "다락방 참여코드 조회 성공!"),
+		@ApiResponse(responseCode = "403", description = "권한이 없습니다."),
+	})
+	ResponseEntity<RestResponse<InvitationCodeResponse>> findInvitationCode(
+		@PathVariable Long darakbangId,
 		@LoginMember Member member
 	);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
+++ b/backend/src/main/java/mouda/backend/darakbang/controller/DarakbangSwagger.java
@@ -37,7 +37,9 @@ public interface DarakbangSwagger {
 	@Operation(summary = "다락방 참여코드 조회", description = "참여한 다락방 참여코드를 조회한다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "다락방 참여코드 조회 성공!"),
-		@ApiResponse(responseCode = "403", description = "권한이 없습니다."),
+		@ApiResponse(responseCode = "403", description = "조회 권한이 없습니다."),
+		@ApiResponse(responseCode = "404", description = "존재하지 않는 다락방 멤버입니다."),
+		@ApiResponse(responseCode = "404", description = "다락방이 존재하지 않습니다."),
 	})
 	ResponseEntity<RestResponse<InvitationCodeResponse>> findInvitationCode(
 		@PathVariable Long darakbangId,

--- a/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangEnterRequest.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangEnterRequest.java
@@ -6,7 +6,7 @@ import mouda.backend.darakbangmember.domain.DarakBangMemberRole;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 import mouda.backend.member.domain.Member;
 
-public record DarakbangJoinRequest(
+public record DarakbangEnterRequest(
 	@NotNull
 	String nickname
 ) {

--- a/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangJoinRequest.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/request/DarakbangJoinRequest.java
@@ -1,0 +1,21 @@
+package mouda.backend.darakbang.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbangmember.domain.DarakBangMemberRole;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.member.domain.Member;
+
+public record DarakbangJoinRequest(
+	@NotNull
+	String nickname
+) {
+	public DarakbangMember toEntity(Darakbang darakbang, Member member) {
+		return DarakbangMember.builder()
+			.darakbang(darakbang)
+			.member(member)
+			.nickname(nickname)
+			.role(DarakBangMemberRole.MEMBER)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/CodeValidationResponse.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/CodeValidationResponse.java
@@ -1,0 +1,15 @@
+package mouda.backend.darakbang.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CodeValidationResponse(
+	boolean isValid
+) {
+
+	public static CodeValidationResponse toResponse(boolean isValid) {
+		return CodeValidationResponse.builder()
+			.isValid(isValid)
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/CodeValidationResponse.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/CodeValidationResponse.java
@@ -4,12 +4,12 @@ import lombok.Builder;
 
 @Builder
 public record CodeValidationResponse(
-	boolean isValid
+	String name
 ) {
 
-	public static CodeValidationResponse toResponse(boolean isValid) {
+	public static CodeValidationResponse toResponse(String name) {
 		return CodeValidationResponse.builder()
-			.isValid(isValid)
+			.name(name)
 			.build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/dto/response/InvitationCodeResponse.java
+++ b/backend/src/main/java/mouda/backend/darakbang/dto/response/InvitationCodeResponse.java
@@ -1,0 +1,16 @@
+package mouda.backend.darakbang.dto.response;
+
+import lombok.Builder;
+import mouda.backend.darakbang.domain.Darakbang;
+
+@Builder
+public record InvitationCodeResponse(
+	String code
+) {
+
+	public static InvitationCodeResponse toResponse(Darakbang darakbang) {
+		return InvitationCodeResponse.builder()
+			.code(darakbang.getCode())
+			.build();
+	}
+}

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
@@ -10,7 +10,9 @@ public enum DarakbangErrorMessage {
 	NAME_ALREADY_EXIST("이미 존재하는 다락방 이름입니다."),
 	NAME_NOT_EXIST("다락방 이름이 존재하지 않습니다."),
 	CODE_NOT_EXIST("다락방 초대 코드가 존재하지 않습니다."),
-	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다");
+	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다"),
+	DARAKBANG_NOT_FOUND("다락방이 존재하지 않습니다"),
+	;
 
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
@@ -9,7 +9,7 @@ public enum DarakbangErrorMessage {
 
 	NAME_ALREADY_EXIST("이미 존재하는 다락방 이름입니다."),
 	NAME_NOT_EXIST("다락방 이름이 존재하지 않습니다."),
-	CODE_NOT_EXIST("다락방 초대 코드가 존재하지 않습니다."),
+	INVALID_CODE("유효하지 않은 초대코드입니다."),
 	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다."),
 	DARAKBANG_NOT_FOUND("다락방이 존재하지 않습니다."),
 	;

--- a/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbang/exception/DarakbangErrorMessage.java
@@ -10,8 +10,8 @@ public enum DarakbangErrorMessage {
 	NAME_ALREADY_EXIST("이미 존재하는 다락방 이름입니다."),
 	NAME_NOT_EXIST("다락방 이름이 존재하지 않습니다."),
 	CODE_NOT_EXIST("다락방 초대 코드가 존재하지 않습니다."),
-	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다"),
-	DARAKBANG_NOT_FOUND("다락방이 존재하지 않습니다"),
+	CODE_ALREADY_EXIST("이미 존재하는 초대코드입니다."),
+	DARAKBANG_NOT_FOUND("다락방이 존재하지 않습니다."),
 	;
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbang/repository/DarakbangRepository.java
@@ -1,5 +1,7 @@
 package mouda.backend.darakbang.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,6 @@ public interface DarakbangRepository extends JpaRepository<Darakbang, Long> {
 	boolean existsByName(String name);
 
 	boolean existsByCode(String code);
+
+	Optional<Darakbang> findByCode(String code);
 }

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
+import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponse;
 import mouda.backend.darakbang.dto.response.DarakbangResponses;
 import mouda.backend.darakbang.dto.response.InvitationCodeResponse;
@@ -69,6 +70,7 @@ public class DarakbangService {
 		return DarakbangResponses.toResponse(responses);
 	}
 
+	@Transactional(readOnly = true)
 	public InvitationCodeResponse findInvitationCode(Long darakbangId, Member member) {
 		DarakBangMemberRole role = darakbangMemberRepository.findByDarakbangIdAndMemberId(darakbangId, member.getId())
 			.orElseThrow(() -> new DarakbangMemberException(HttpStatus.NOT_FOUND,
@@ -83,5 +85,13 @@ public class DarakbangService {
 			.orElseThrow(() -> new DarakbangException(HttpStatus.NOT_FOUND, DarakbangErrorMessage.DARAKBANG_NOT_FOUND));
 
 		return InvitationCodeResponse.toResponse(darakbang);
+	}
+
+	@Transactional(readOnly = true)
+	public CodeValidationResponse validateCode(String code) {
+		if (darakbangRepository.existsByCode(code)) {
+			return CodeValidationResponse.toResponse(true);
+		}
+		return CodeValidationResponse.toResponse(false);
 	}
 }

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -73,12 +73,12 @@ public class DarakbangService {
 
 	@Transactional(readOnly = true)
 	public InvitationCodeResponse findInvitationCode(Long darakbangId, Member member) {
-		DarakBangMemberRole role = darakbangMemberRepository.findByDarakbangIdAndMemberId(darakbangId, member.getId())
+		DarakbangMember darakbangMember = darakbangMemberRepository
+			.findByDarakbangIdAndMemberId(darakbangId, member.getId())
 			.orElseThrow(() -> new DarakbangMemberException(HttpStatus.NOT_FOUND,
-				DarakbangMemberErrorMessage.DARAKBANG_MEMBER_NOT_EXIST))
-			.getRole();
+				DarakbangMemberErrorMessage.DARAKBANG_MEMBER_NOT_EXIST));
 
-		if (role != DarakBangMemberRole.MANAGER) {
+		if (darakbangMember.isNotManager()) {
 			throw new DarakbangMemberException(HttpStatus.FORBIDDEN, DarakbangMemberErrorMessage.NOT_ALLOWED_TO_READ);
 		}
 

--- a/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/service/DarakbangService.java
@@ -90,10 +90,10 @@ public class DarakbangService {
 
 	@Transactional(readOnly = true)
 	public CodeValidationResponse validateCode(String code) {
-		if (darakbangRepository.existsByCode(code)) {
-			return CodeValidationResponse.toResponse(true);
-		}
-		return CodeValidationResponse.toResponse(false);
+		Darakbang darakbang = darakbangRepository.findByCode(code)
+			.orElseThrow(() -> new DarakbangException(HttpStatus.BAD_REQUEST, DarakbangErrorMessage.INVALID_CODE));
+
+		return CodeValidationResponse.toResponse(darakbang.getName());
 	}
 
 	public Darakbang enter(String code, DarakbangEnterRequest request, Member member) {

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -59,6 +59,10 @@ public class DarakbangMember {
 		}
 	}
 
+	public boolean isNotManager() {
+		return role != DarakBangMemberRole.MANAGER;
+	}
+
 	public String getDarakbangName() {
 		return darakbang.getName();
 	}

--- a/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum DarakbangMemberErrorMessage {
 
 	NICKNAME_NOT_EXIST("닉네임이 존재하지 않습니다."),
+	DARAKBANG_MEMBER_NOT_EXIST("존재하지 않는 다락방 멤버입니다."),
+	NOT_ALLOWED_TO_READ("조회 권한이 없습니다."),
 	;
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum DarakbangMemberErrorMessage {
 
 	NICKNAME_NOT_EXIST("닉네임이 존재하지 않습니다."),
+	NICKNAME_ALREADY_EXIST("이미 존재하는 닉네임입니다."),
+	MEMBER_ALREADY_EXIST("이미 가입한 멤버입니다."),
 	DARAKBANG_MEMBER_NOT_EXIST("존재하지 않는 다락방 멤버입니다."),
 	NOT_ALLOWED_TO_READ("조회 권한이 없습니다."),
 	;

--- a/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
@@ -1,6 +1,7 @@
 package mouda.backend.darakbangmember.repository.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ import mouda.backend.darakbangmember.domain.DarakbangMember;
 public interface DarakbangMemberRepository extends JpaRepository<DarakbangMember, Long> {
 
 	List<DarakbangMember> findAllByMemberId(long memberId);
+
+	Optional<DarakbangMember> findByDarakbangIdAndMemberId(Long darakbangId, Long id);
 }

--- a/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/repository/repository/DarakbangMemberRepository.java
@@ -14,4 +14,8 @@ public interface DarakbangMemberRepository extends JpaRepository<DarakbangMember
 	List<DarakbangMember> findAllByMemberId(long memberId);
 
 	Optional<DarakbangMember> findByDarakbangIdAndMemberId(Long darakbangId, Long id);
+
+	boolean existsByDarakbangIdAndMemberId(Long darakbangId, Long id);
+
+	boolean existsByDarakbangIdAndNickname(Long id, String nickname);
 }

--- a/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -17,6 +18,7 @@ import mouda.backend.config.DatabaseCleaner;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbang.dto.request.DarakbangCreateRequest;
 import mouda.backend.darakbang.dto.request.DarakbangEnterRequest;
+import mouda.backend.darakbang.dto.response.CodeValidationResponse;
 import mouda.backend.darakbang.exception.DarakbangException;
 import mouda.backend.darakbang.repository.DarakbangRepository;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
@@ -189,6 +191,34 @@ class DarakbangServiceTest {
 
 			assertThatThrownBy(() -> darakbangService.enter(darakbang.getCode(), enterRequest, anna))
 				.isInstanceOf(DarakbangMemberException.class);
+		}
+	}
+
+	@DisplayName("다락방 초대코드 검증 테스트")
+	@Nested
+	class DarakbangCodeValidateTest {
+
+		@DisplayName("다락방 초대코드 유효성 검증에 성공한다.")
+		@Test
+		void success() {
+			memberRepository.save(MemberFixture.getHogee());
+			Darakbang darakbang = darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+
+			CodeValidationResponse codeValidationResponse = darakbangService.validateCode(darakbang.getCode());
+
+			assertThat(codeValidationResponse.name()).isNotBlank();
+		}
+
+		@DisplayName("다락방 초대코드 유효성 검증에 실패한다.")
+		@ValueSource(strings = "INVALID")
+		@NullAndEmptySource
+		@ParameterizedTest
+		void failToValidateCode(String code) {
+			memberRepository.save(MemberFixture.getHogee());
+			darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+
+			assertThatThrownBy(() -> darakbangService.validateCode(code))
+				.isInstanceOf(DarakbangException.class);
 		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
+++ b/backend/src/test/java/mouda/backend/darakbang/service/DarakbangServiceTest.java
@@ -19,6 +19,7 @@ import mouda.backend.darakbang.repository.DarakbangRepository;
 import mouda.backend.darakbangmember.exception.DarakbangMemberException;
 import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
 import mouda.backend.fixture.DarakbangFixture;
+import mouda.backend.fixture.DarakbangMemberFixture;
 import mouda.backend.fixture.MemberFixture;
 import mouda.backend.member.domain.Member;
 import mouda.backend.member.repository.MemberRepository;
@@ -113,6 +114,32 @@ class DarakbangServiceTest {
 			assertThatThrownBy(() -> darakbangService.createDarakbang(request, hogee))
 				.isInstanceOf(DarakbangException.class);
 		}
+	}
 
+	@DisplayName("다락방 초대코드 조회 테스트")
+	@Nested
+	class DarakbangInvitationCodeReadTest {
+
+		@DisplayName("다락방 초대코드를 성공적으로 조회한다.")
+		@Test
+		void success() {
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Darakbang darakbang = darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+			darakbangMemberRepository.save(DarakbangMemberFixture.getDarakbangManagerWithWooteco(darakbang, hogee));
+
+			assertThatNoException()
+				.isThrownBy(() -> darakbangService.findInvitationCode(darakbang.getId(), hogee));
+		}
+
+		@DisplayName("관리자가 아니라면 초대코드 조회에 실패한다.")
+		@Test
+		void failToReadByNotManager() {
+			Member hogee = memberRepository.save(MemberFixture.getHogee());
+			Darakbang darakbang = darakbangRepository.save(DarakbangFixture.getDarakbangWithWooteco());
+			darakbangMemberRepository.save(DarakbangMemberFixture.getDarakbangMemberWithWooteco(darakbang, hogee));
+
+			assertThatThrownBy(() -> darakbangService.findInvitationCode(darakbang.getId(), hogee))
+				.isInstanceOf(DarakbangMemberException.class);
+		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/fixture/DarakbangMemberFixture.java
+++ b/backend/src/test/java/mouda/backend/fixture/DarakbangMemberFixture.java
@@ -1,0 +1,27 @@
+package mouda.backend.fixture;
+
+import mouda.backend.darakbang.domain.Darakbang;
+import mouda.backend.darakbangmember.domain.DarakBangMemberRole;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.member.domain.Member;
+
+public class DarakbangMemberFixture {
+
+	public static DarakbangMember getDarakbangManagerWithWooteco(Darakbang darakbang, Member member) {
+		return DarakbangMember.builder()
+			.darakbang(darakbang)
+			.member(member)
+			.nickname("호호기기")
+			.role(DarakBangMemberRole.MANAGER)
+			.build();
+	}
+
+	public static DarakbangMember getDarakbangMemberWithWooteco(Darakbang darakbang, Member member) {
+		return DarakbangMember.builder()
+			.darakbang(darakbang)
+			.member(member)
+			.nickname("소소파파")
+			.role(DarakBangMemberRole.MEMBER)
+			.build();
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

초대코드 조회, 초대코드 유효성 검사, 다락방 참여 기능을 추가합니다.

## 이슈 ID는 무엇인가요?

- #349 

## 설명

- 참여코드 존재 여부로만 유효성 검증을 진행합니다.
  - 참여코드가 유효하다면(존재한다면) 해당 다락방의 이름을 반환합니다.
- 다락방에 참여 시 참여코드와 닉네임을 받습니다.
- 다락방 초대코드는 관리자만 조회 가능합니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
