### PR TITLE
알림 센터 API 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/notification/controller/NotificationController.java
+++ b/backend/src/main/java/mouda/backend/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package mouda.backend.notification.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,9 +9,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.member.domain.Member;
 import mouda.backend.notification.dto.request.FcmTokenSaveRequest;
+import mouda.backend.notification.dto.response.NotificationFindAllResponses;
 import mouda.backend.notification.service.NotificationService;
 
 @RestController
@@ -29,5 +32,14 @@ public class NotificationController implements NotificationSwagger {
 		notificationService.registerFcmToken(member.getId(), fcmTokenSaveRequest);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@Override
+	@GetMapping("/mine")
+	public ResponseEntity<RestResponse<NotificationFindAllResponses>> findAllMyNotification(
+		@LoginMember Member member) {
+		NotificationFindAllResponses responses = notificationService.findAllMyNotifications(member);
+
+		return ResponseEntity.ok().body(new RestResponse<>(responses));
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/controller/NotificationSwagger.java
+++ b/backend/src/main/java/mouda/backend/notification/controller/NotificationSwagger.java
@@ -7,9 +7,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import mouda.backend.common.RestResponse;
 import mouda.backend.config.argumentresolver.LoginMember;
 import mouda.backend.member.domain.Member;
 import mouda.backend.notification.dto.request.FcmTokenSaveRequest;
+import mouda.backend.notification.dto.response.NotificationFindAllResponses;
 
 public interface NotificationSwagger {
 
@@ -21,4 +23,10 @@ public interface NotificationSwagger {
 		@LoginMember Member member,
 		@Valid @RequestBody FcmTokenSaveRequest fcmTokenSaveRequest
 	);
+
+	@Operation(summary = "모든 알림 조회", description = "회원의 모든 알림을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "알림 조회 성공!")
+	})
+	ResponseEntity<RestResponse<NotificationFindAllResponses>> findAllMyNotification(@LoginMember Member member);
 }

--- a/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
+++ b/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
@@ -1,5 +1,8 @@
 package mouda.backend.notification.dto.response;
 
+import lombok.Builder;
+
+@Builder
 public record NotificationFindAllResponse(
 	String message,
 	String createdAt,

--- a/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
+++ b/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
@@ -1,0 +1,8 @@
+package mouda.backend.notification.dto.response;
+
+public record NotificationFindAllResponse(
+	String message,
+	String createdAt,
+	String type
+) {
+}

--- a/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponses.java
+++ b/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponses.java
@@ -1,0 +1,8 @@
+package mouda.backend.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationFindAllResponses(
+	List<NotificationFindAllResponse> notifications
+) {
+}

--- a/backend/src/main/java/mouda/backend/notification/repository/MemberNotificationRepository.java
+++ b/backend/src/main/java/mouda/backend/notification/repository/MemberNotificationRepository.java
@@ -1,8 +1,12 @@
 package mouda.backend.notification.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import mouda.backend.notification.domain.MemberNotification;
 
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
+
+	List<MemberNotification> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -152,11 +152,11 @@ public class NotificationService {
 		List<NotificationFindAllResponse> responses = memberNotificationRepository.findAllByMemberId(member.getId())
 			.stream()
 			.map(MemberNotification::getMoudaNotification)
-			.map(moudaNotification -> new NotificationFindAllResponse(
-				moudaNotification.getBody(),
-				parseTime(moudaNotification.getCreatedAt()),
-				moudaNotification.getType().name()
-			))
+			.map(moudaNotification -> NotificationFindAllResponse.builder()
+				.message(moudaNotification.getBody())
+				.createdAt(parseTime(moudaNotification.getCreatedAt()))
+				.type(moudaNotification.getType().name())
+				.build())
 			.toList();
 
 		return new NotificationFindAllResponses(responses);

--- a/backend/src/test/java/mouda/backend/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/mouda/backend/notification/service/NotificationServiceTest.java
@@ -1,0 +1,92 @@
+package mouda.backend.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import io.restassured.RestAssured;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.repository.MemberRepository;
+import mouda.backend.notification.domain.MemberNotification;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.dto.response.NotificationFindAllResponse;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class NotificationServiceTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MoudaNotificationRepository moudaNotificationRepository;
+
+	@Autowired
+	private MemberNotificationRepository memberNotificationRepository;
+
+	@Autowired
+	private NotificationService notificationService;
+
+	@LocalServerPort
+	private int port;
+
+	@BeforeEach
+	void setUp() {
+		RestAssured.port = port;
+	}
+
+	@DisplayName("회원의 모든 알림을 조회한다.")
+	@Test
+	void findAllMyNotifications() {
+		NotificationType type1 = NotificationType.MOIM_CREATED;
+		MoudaNotification notification1 = moudaNotificationRepository.save(MoudaNotification.builder()
+			.type(type1)
+			.body(type1.createMessage("테스트모임"))
+			.targetUrl("test")
+			.build());
+
+		NotificationType type2 = NotificationType.NEW_CHAT;
+		MoudaNotification notification2 = moudaNotificationRepository.save(MoudaNotification.builder()
+			.type(type2)
+			.body(type2.createMessage("상돌"))
+			.targetUrl("test")
+			.build());
+
+		Member member = memberRepository.save(Member.builder()
+			.nickname("상돌")
+			.kakaoId(1234L)
+			.build());
+
+		memberNotificationRepository.save(MemberNotification.builder()
+			.memberId(member.getId())
+			.moudaNotification(notification1)
+			.build());
+
+		memberNotificationRepository.save(MemberNotification.builder()
+			.memberId(member.getId())
+			.moudaNotification(notification2)
+			.build());
+
+		List<NotificationFindAllResponse> responses = notificationService.findAllMyNotifications(member)
+			.notifications();
+
+		assertThat(responses).satisfies(res -> {
+			assertThat(res).hasSize(2);
+			assertThat(res).extracting(NotificationFindAllResponse::message)
+				.containsExactly(type1.createMessage("테스트모임"), type2.createMessage("상돌"));
+			assertThat(res).extracting(NotificationFindAllResponse::createdAt)
+				.containsExactly("방금 전", "방금 전");
+			assertThat(res).extracting(NotificationFindAllResponse::type)
+				.containsExactly(type1.toString(), type2.toString());
+		});
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

알림 센터에서 회원의 알림 목록을 불러오는 API를 구현했어요.

## 이슈 ID는 무엇인가요?

- #361 

## 설명

- 채팅(새로운 메시지) 알림은 알림센터에서 조회되진 않아요.
- 토큰과 무관한 기능이라 테스트 코드를 간단하게 작성했어요.
- 자세한 내용은 노션의 API 명세에서 확인하실 수 있어요.

## 질문 혹은 공유 사항 (Optional)

- 다락방 관련 기능은 아직 반영하진 않았습니다! 