### PR TITLE
알림 클릭 시, 해당 페이지로 이동하는 클릭 이벤트 추가

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -16,6 +16,34 @@ self.addEventListener("activate", function () {
   console.log("fcm service worker가 실행되었습니다.");
 });
 
+self.addEventListener('notificationclick', function(event) {
+  console.log('[firebase-messaging-sw.js] 알림이 클릭되었습니다.');
+
+  // 알림 데이터를 가져오기
+  const link = event.notification.data.FCM_MSG.notification.click_action;
+
+  event.notification.close(); // 알림 닫기
+
+  // 사용자가 알림을 클릭했을 때 해당 링크로 이동
+  if (link) {
+    event.waitUntil(
+      clients.matchAll({ type: 'window', includeUncontrolled: true }).then(windowClients => {
+        // 이미 열린 창이 있는지 확인
+        for (let i = 0; i < windowClients.length; i++) {
+          const client = windowClients[i];
+          if (client.url === link && 'focus' in client) {
+            return client.focus();
+          }
+        }
+        // 새 창을 열거나 이미 있는 창으로 이동
+        if (clients.openWindow) {
+          return clients.openWindow(link);
+        }
+      })
+    );
+  }
+});
+
 firebase.initializeApp(firebaseConfig);
 
 const messaging = firebase.messaging();
@@ -30,4 +58,3 @@ messaging.onBackgroundMessage((payload) => {
   };
   self.registration.showNotification(notificationTitle, notificationOptions);
 });
-

--- a/frontend/src/service/forgroundMessage.ts
+++ b/frontend/src/service/forgroundMessage.ts
@@ -1,14 +1,32 @@
 import { getMessaging, onMessage } from 'firebase/messaging';
 import { app } from './initFirebase';
+
+// Firebase Messaging 인스턴스 가져오기
 const messaging = getMessaging(app);
+
 onMessage(messaging, (payload) => {
-  console.log('알림 도착 ', payload);
+  console.log('포그라운드 알림 도착: ', payload);
+
   const notificationTitle = payload.notification?.title;
   const notificationOptions = {
     body: payload.notification?.body,
+    icon: payload.notification?.icon, // 알림 아이콘 설정
+    data: { link: payload.fcmOptions?.link || '/' }, // 알림 클릭 시 이동할 링크 설정
   };
 
   if (Notification.permission === 'granted') {
-    new Notification(notificationTitle!, notificationOptions);
+    const notification = new Notification(
+      notificationTitle!,
+      notificationOptions,
+    );
+
+    notification.onclick = function (event) {
+      event.preventDefault(); // 기본 동작 방지 (필요한 경우)
+
+      // 알림 클릭 시 페이지 이동
+      window.open(notificationOptions.data.link, '_blank');
+    };
+  } else {
+    console.warn('알림 권한이 허용되지 않았습니다.');
   }
 });


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

현재 알림 클릭 시, 별다른 이벤트가 발생하지 않는다. 이때 해당 알림과 연관된 페이지로 이동하면 이용성이 증가될 것이다.

## 이슈 ID는 무엇인가요?

- #370

## 설명

forground 알림과 background 알림에 알림 클릭 이벤트 리스너를 달아 두었습니다.
서버에서 보내는 알림 payload에 알림 관련 정보가 담겨 있는데, 그 안에 이동했으면 좋겠는 url 주소가 포함되어 있습니다. 
알림 클릭 시, 해당 페이지로 이동하는 로직을 작성했으니 확인 부탁드립니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
