### PR TITLE
알림 기능 오류 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/config/CorsConfig.java
+++ b/backend/src/main/java/mouda/backend/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("http://localhost:8080", "https://dev.mouda.site")
+			.allowedOrigins("http://localhost:8081", "https://dev.mouda.site")
 			.allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
 			.allowedHeaders("Authorization", "Content-Type")
 			.allowCredentials(true)

--- a/backend/src/main/java/mouda/backend/notification/domain/MoudaNotification.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/MoudaNotification.java
@@ -6,6 +6,8 @@ import com.google.firebase.messaging.Notification;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,6 +32,7 @@ public class MoudaNotification {
 	@Column(nullable = false)
 	private String targetUrl;
 
+	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false)
 	private NotificationType type;
 

--- a/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
+++ b/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
@@ -10,7 +10,8 @@ import mouda.backend.notification.domain.MoudaNotification;
 public record NotificationFindAllResponse(
 	String message,
 	String createdAt,
-	String type
+	String type,
+	String redirectUrl
 ) {
 
 	public static NotificationFindAllResponse from(MoudaNotification moudaNotification) {
@@ -18,6 +19,7 @@ public record NotificationFindAllResponse(
 			.type(moudaNotification.getType().name())
 			.message(moudaNotification.getBody())
 			.createdAt(parseTime(moudaNotification.getCreatedAt()))
+			.redirectUrl(moudaNotification.getTargetUrl())
 			.build();
 	}
 

--- a/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
+++ b/backend/src/main/java/mouda/backend/notification/dto/response/NotificationFindAllResponse.java
@@ -1,6 +1,10 @@
 package mouda.backend.notification.dto.response;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import lombok.Builder;
+import mouda.backend.notification.domain.MoudaNotification;
 
 @Builder
 public record NotificationFindAllResponse(
@@ -8,4 +12,30 @@ public record NotificationFindAllResponse(
 	String createdAt,
 	String type
 ) {
+
+	public static NotificationFindAllResponse from(MoudaNotification moudaNotification) {
+		return NotificationFindAllResponse.builder()
+			.type(moudaNotification.getType().name())
+			.message(moudaNotification.getBody())
+			.createdAt(parseTime(moudaNotification.getCreatedAt()))
+			.build();
+	}
+
+	private static String parseTime(LocalDateTime notificationCreatedAt) {
+		LocalDateTime now = LocalDateTime.now();
+		long minutes = notificationCreatedAt.until(now, ChronoUnit.MINUTES);
+		long hours = notificationCreatedAt.until(now, ChronoUnit.HOURS);
+		long days = notificationCreatedAt.until(now, ChronoUnit.DAYS);
+
+		if (minutes == 0) {
+			return "방금 전";
+		}
+		if (minutes < 60) {
+			return minutes + "분 전";
+		}
+		if (hours < 24) {
+			return hours + "시간 전";
+		}
+		return days + "일 전";
+	}
 }

--- a/backend/src/main/java/mouda/backend/notification/repository/FcmTokenRepository.java
+++ b/backend/src/main/java/mouda/backend/notification/repository/FcmTokenRepository.java
@@ -11,10 +11,11 @@ import mouda.backend.notification.domain.FcmToken;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
-	Optional<FcmToken> findFcmTokenByMemberId(long memberId);
+	@Query("SELECT f.token FROM FcmToken f WHERE f.memberId = :memberId")
+	List<String> findAllTokenByMemberId(@Param("memberId") Long memberId);
 
 	@Query("SELECT f.token FROM FcmToken f WHERE f.memberId IN :memberIds")
-	List<String> findTokensByMemberIds(@Param("memberIds") List<Long> memberIds);
+	List<String> findAllTokenByMemberIds(@Param("memberIds") List<Long> memberIds);
 
 	@Query("SELECT f.memberId FROM FcmToken f")
 	List<Long> findAllMemberId();

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -1,7 +1,5 @@
 package mouda.backend.notification.service;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 
@@ -134,31 +132,9 @@ public class NotificationService {
 		List<NotificationFindAllResponse> responses = memberNotificationRepository.findAllByMemberId(member.getId())
 			.stream()
 			.map(MemberNotification::getMoudaNotification)
-			.map(moudaNotification -> NotificationFindAllResponse.builder()
-				.message(moudaNotification.getBody())
-				.createdAt(parseTime(moudaNotification.getCreatedAt()))
-				.type(moudaNotification.getType().name())
-				.build())
+			.map(NotificationFindAllResponse::from)
 			.toList();
 
 		return new NotificationFindAllResponses(responses);
-	}
-
-	private String parseTime(LocalDateTime notificationCreatedAt) {
-		LocalDateTime now = LocalDateTime.now();
-		long minutes = notificationCreatedAt.until(now, ChronoUnit.MINUTES);
-		long hours = notificationCreatedAt.until(now, ChronoUnit.HOURS);
-		long days = notificationCreatedAt.until(now, ChronoUnit.DAYS);
-
-		if (minutes == 0) {
-			return "방금 전";
-		}
-		if (minutes < 60) {
-			return minutes + "분 전";
-		}
-		if (hours < 24) {
-			return hours + "시간 전";
-		}
-		return days + "일 전";
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -95,11 +95,6 @@ public class NotificationService {
 		}
 
 		List<String> tokens = fcmTokenRepository.findAllTokenByMemberIds(memberIds);
-
-		if (tokens.isEmpty()) {
-			return;
-		}
-
 		sendNotificationToAll(notification, tokens);
 	}
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -25,4 +25,4 @@ oauth:
     redirect-uri: http://localhost:8081/kakao-o-auth
 
 url:
-  base: http://localhost:8080
+  base: http://localhost:8081

--- a/backend/src/test/java/mouda/backend/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/mouda/backend/notification/service/NotificationServiceTest.java
@@ -83,8 +83,6 @@ class NotificationServiceTest {
 			assertThat(res).hasSize(2);
 			assertThat(res).extracting(NotificationFindAllResponse::message)
 				.containsExactly(type1.createMessage("테스트모임"), type2.createMessage("상돌"));
-			assertThat(res).extracting(NotificationFindAllResponse::createdAt)
-				.containsExactly("방금 전", "방금 전");
 			assertThat(res).extracting(NotificationFindAllResponse::type)
 				.containsExactly(type1.toString(), type2.toString());
 		});


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

알림 기능에서 구현이 안되거나 미비한 부분을 수정했어요.

## 이슈 ID는 무엇인가요?

- close #374 

## 설명

- [x] 프론트엔드가 로컬 환경에서 테스트할때는 8081 포트를 사용해서, 알림에 지정되는 경로와 CORS 설정 경로를 8081 포트로 수정
- [x] 하나의 멤버가 여러 토큰을 가질 수 있어야 하는데, 기존의 단건 전송에서는 하나의 토큰만 조회하도록 되어있던 부분을 수정
- [x] 여러 토큰(여러 기기)에 보낼 때 사용하는 MulticastMessage는 최대 500개의 토큰까지만 담을 수 있기에, 알림을 보낼 때 토큰을 500개 단위로 쪼개 보내도록 수정
- [x] 알림 타입(NotificationType) 필드를 EnumType.String으로 지정
- [x] 알림 센터에서 해당 알림을 선택했을 때 이동하는 경로 추가

## 질문 혹은 공유 사항 (Optional)

지금은 알림 센터 API에서 알림 시간을 조회할 때의 형식을 서버에서 변환하고 있습니다. 지난 PR에서 문의 주셨던 대로 작업에 여유가 생기면 프론트에서 처리할 부분이기에 우선 서비스가 아닌 DTO로 해당 로직을 이동했습니다. 

문서화는 열심히 하고 있어요~! 오늘까지 최대한 작성해볼게요.

(추가)
**노션의 팀 블로그에 구현 과정 글을 작성했어요. 그 글을 먼저 읽고 보는게 이해가 빠를거에요!**
