### PR TITLE
알림에 다락방 기능 반영

### DIFF
--- a/backend/src/main/java/mouda/backend/chamyo/repository/ChamyoRepository.java
+++ b/backend/src/main/java/mouda/backend/chamyo/repository/ChamyoRepository.java
@@ -26,7 +26,7 @@ public interface ChamyoRepository extends JpaRepository<Chamyo, Long> {
 
 	void deleteByMoimIdAndMemberId(Long moimId, Long memberId);
 
-	@Query("SELECT c.member.id FROM Chamyo c WHERE c.moim.id = :moimId AND c.moimRole = 'MOIMER'")
+	@Query("SELECT c.member.member.id FROM Chamyo c WHERE c.moim.id = :moimId AND c.moimRole = 'MOIMER'")
 	Long findMoimerIdByMoimId(@Param("moimId") Long moimId);
 
 	List<Chamyo> findAllByMemberIdAndMoim_DarakbangId(Long memberId, Long darakbangId);

--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -88,11 +88,11 @@ public class ChamyoService {
 			.build();
 
 		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
-			.map(c -> c.getMember().getId())
-			.filter(memberId -> !memberId.equals(member.getId()))
+			.map(c -> c.getMember().getMember().getId())
+			.filter(memberId -> !memberId.equals(member.getMember().getId()))
 			.toList();
 
-		notificationService.notifyToMembers(notification, membersToSendNotification);
+		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
 	}
 
 	private void validateCanChamyoMoim(Moim moim, DarakbangMember member) {
@@ -131,7 +131,7 @@ public class ChamyoService {
 			.build();
 
 		Long moimerId = chamyoRepository.findMoimerIdByMoimId(moim.getId());
-		notificationService.notifyToMember(notification, moimerId);
+		notificationService.notifyToMember(notification, moimerId, darakbangId);
 	}
 
 	private void validateCanCancelChamyo(Moim moim, DarakbangMember member) {

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -76,7 +76,7 @@ public class ChatService {
 	}
 
 	@Transactional(readOnly = true)
-	public ChatFindUnloadedResponse findUnloadedChats(long recentChatId, long moimId, DarakbangMember member) {
+	public ChatFindUnloadedResponse findUnloadedChats(long moimId, long recentChatId, DarakbangMember member) {
 		findMoimByMoimId(moimId);
 		findChamyoByMoimIdAndMemberId(moimId, member.getId());
 		if (recentChatId < 0) {

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -68,11 +68,11 @@ public class ChatService {
 			.build();
 
 		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
-			.map(chamyo -> chamyo.getMember().getId())
-			.filter(memberId -> !Objects.equals(memberId, member.getId()))
+			.map(chamyo -> chamyo.getMember().getMember().getId())
+			.filter(memberId -> !Objects.equals(memberId, member.getMember().getId()))
 			.toList();
 
-		notificationService.notifyToMembers(notification, membersToSendNotification);
+		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
 	}
 
 	@Transactional(readOnly = true)
@@ -105,10 +105,11 @@ public class ChatService {
 		moim.confirmPlace(placeConfirmRequest.place());
 		chatRepository.save(chat);
 
-		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_PLACE_CONFIRMED);
+		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_PLACE_CONFIRMED, darakbangId);
 	}
 
-	private void sendNotificationWhenMoimPlaceOrTimeConfirmed(Moim moim, NotificationType notificationType) {
+	private void sendNotificationWhenMoimPlaceOrTimeConfirmed(Moim moim, NotificationType notificationType,
+		Long darakbangId) {
 		MoudaNotification notification = MoudaNotification.builder()
 			.type(notificationType)
 			.body(notificationType.createMessage(moim.getTitle()))
@@ -117,10 +118,10 @@ public class ChatService {
 
 		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
 			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
-			.map(chamyo -> chamyo.getMember().getId())
+			.map(chamyo -> chamyo.getMember().getMember().getId())
 			.toList();
 
-		notificationService.notifyToMembers(notification, membersToSendNotification);
+		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
 	}
 
 	@RequiredDarakbangMoim
@@ -137,7 +138,7 @@ public class ChatService {
 		moim.confirmDateTime(dateTimeConfirmRequest.date(), dateTimeConfirmRequest.time());
 		chatRepository.save(chat);
 
-		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_TIME_CONFIRMED);
+		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_TIME_CONFIRMED, darakbangId);
 	}
 
 	public ChatPreviewResponses findChatPreview(Long darakbangId, DarakbangMember member) {

--- a/backend/src/main/java/mouda/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/mouda/backend/comment/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import mouda.backend.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-	@Query("SELECT c.member.id FROM Comment c WHERE c.parentId = :parentId")
+	@Query("SELECT c.member.member.id FROM Comment c WHERE c.parentId = :parentId")
 	Long findMemberIdByParentId(@Param("parentId") long parentId);
 
 	List<Comment> findAllByMoimIdOrderByCreatedAt(long id);

--- a/backend/src/main/java/mouda/backend/config/FirebaseConfig.java
+++ b/backend/src/main/java/mouda/backend/config/FirebaseConfig.java
@@ -3,6 +3,7 @@ package mouda.backend.config;
 import java.io.InputStream;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -11,6 +12,7 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 
 @Configuration
+@Profile("dev")
 public class FirebaseConfig {
 
 	@PostConstruct
@@ -21,7 +23,9 @@ public class FirebaseConfig {
 			FirebaseOptions options = new FirebaseOptions.Builder()
 				.setCredentials(GoogleCredentials.fromStream(serviceAccount))
 				.build();
-			FirebaseApp.initializeApp(options);
+			if (FirebaseApp.getApps().isEmpty()) {
+				FirebaseApp.initializeApp(options);
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -73,7 +73,7 @@ public class MoimService {
 			.targetUrl(baseUrl + moimUrl + "/" + moim.getId())
 			.build();
 
-		notificationService.notifyToAllExceptMember(notification, member.getId());
+		notificationService.notifyToAllExceptMember(notification, member.getMember().getId(), darakbangId);
 		return moim;
 	}
 
@@ -135,10 +135,6 @@ public class MoimService {
 		}
 	}
 
-	public void updateMoimStatusById(long id, MoimStatus status) {
-		moimRepository.updateMoimStatusById(id, status);
-	}
-
 	@RequiredDarakbangMoim
 	public void createComment(Long darakbangId, Long moimId, DarakbangMember member, CommentCreateRequest request) {
 		Moim moim = moimRepository.findById(moimId)
@@ -151,10 +147,10 @@ public class MoimService {
 
 		commentRepository.save(request.toEntity(moim, member));
 
-		sendCommentNotification(moim.getId(), member, parentId);
+		sendCommentNotification(moim.getId(), member, parentId, darakbangId);
 	}
 
-	private void sendCommentNotification(Long moimId, DarakbangMember author, Long parentId) {
+	private void sendCommentNotification(Long moimId, DarakbangMember author, Long parentId, Long darakbangId) {
 		if (parentId != null) {
 			Long parentCommentAuthorId = commentRepository.findMemberIdByParentId(parentId);
 			MoudaNotification notification = MoudaNotification.builder()
@@ -162,7 +158,7 @@ public class MoimService {
 				.body(NotificationType.NEW_REPLY.createMessage(author.getNickname()))
 				.targetUrl(baseUrl + moimUrl + "/" + moimId)
 				.build();
-			notificationService.notifyToMember(notification, parentCommentAuthorId);
+			notificationService.notifyToMember(notification, parentCommentAuthorId, darakbangId);
 		}
 
 		MoudaNotification notification = MoudaNotification.builder()
@@ -170,7 +166,7 @@ public class MoimService {
 			.body(NotificationType.NEW_COMMENT.createMessage(author.getNickname()))
 			.targetUrl(baseUrl + moimUrl + "/" + moimId)
 			.build();
-		notificationService.notifyToMember(notification, chamyoRepository.findMoimerIdByMoimId(moimId));
+		notificationService.notifyToMember(notification, chamyoRepository.findMoimerIdByMoimId(moimId), darakbangId);
 	}
 
 	@RequiredDarakbangMoim
@@ -181,10 +177,10 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.COMPLETED);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIMING_COMPLETED);
+		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIMING_COMPLETED, darakbangId);
 	}
 
-	private void sendNotificationWhenMoimStatusChanged(Moim moim, NotificationType notificationType) {
+	private void sendNotificationWhenMoimStatusChanged(Moim moim, NotificationType notificationType, Long darakbangId) {
 		MoudaNotification notification = MoudaNotification.builder()
 			.type(notificationType)
 			.body(notificationType.createMessage(moim.getTitle()))
@@ -193,10 +189,10 @@ public class MoimService {
 
 		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
 			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
-			.map(chamyo -> chamyo.getMember().getId())
+			.map(chamyo -> chamyo.getMember().getMember().getId())
 			.toList();
 
-		notificationService.notifyToMembers(notification, membersToSendNotification);
+		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
 	}
 
 	private void validateCanCompleteMoim(Moim moim, DarakbangMember member) {
@@ -218,7 +214,7 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.CANCELED);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_CANCELLED);
+		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_CANCELLED, darakbangId);
 	}
 
 	private void validateCanCancelMoim(Moim moim, DarakbangMember member) {
@@ -236,7 +232,7 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.MOIMING);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOINING_REOPENED);
+		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOINING_REOPENED, darakbangId);
 	}
 
 	private void validateCanReopenMoim(Moim moim, DarakbangMember member) {
@@ -273,7 +269,7 @@ public class MoimService {
 			request.description(), chamyoRepository.countByMoim(moim));
 		moimRepository.save(moim);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_MODIFIED);
+		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_MODIFIED, darakbangId);
 	}
 
 	private void validateCanEditMoim(Moim moim, DarakbangMember member) {

--- a/backend/src/main/java/mouda/backend/notification/controller/NotificationController.java
+++ b/backend/src/main/java/mouda/backend/notification/controller/NotificationController.java
@@ -18,16 +18,15 @@ import mouda.backend.notification.dto.response.NotificationFindAllResponses;
 import mouda.backend.notification.service.NotificationService;
 
 @RestController
-@RequestMapping("/v1/darakbang/{darakbangId}/notification")
+@RequestMapping
 @RequiredArgsConstructor
 public class NotificationController implements NotificationSwagger {
 
 	private final NotificationService notificationService;
 
 	@Override
-	@PostMapping("/register")
+	@PostMapping("/v1/notification/register")
 	public ResponseEntity<Void> registerFcmToken(
-		@PathVariable Long darakbangId,
 		@LoginMember Member member,
 		@Valid @RequestBody FcmTokenSaveRequest fcmTokenSaveRequest
 	) {
@@ -37,12 +36,12 @@ public class NotificationController implements NotificationSwagger {
 	}
 
 	@Override
-	@GetMapping("/mine")
+	@GetMapping("/v1/darakbang/{darakbangId}/notification/mine")
 	public ResponseEntity<RestResponse<NotificationFindAllResponses>> findAllMyNotification(
-		@PathVariable Long darakbangId,
-		@LoginMember Member member
+		@LoginMember Member member,
+		@PathVariable Long darakbangId
 	) {
-		NotificationFindAllResponses responses = notificationService.findAllMyNotifications(member);
+		NotificationFindAllResponses responses = notificationService.findAllMyNotifications(member, darakbangId);
 
 		return ResponseEntity.ok().body(new RestResponse<>(responses));
 	}

--- a/backend/src/main/java/mouda/backend/notification/controller/NotificationSwagger.java
+++ b/backend/src/main/java/mouda/backend/notification/controller/NotificationSwagger.java
@@ -21,7 +21,6 @@ public interface NotificationSwagger {
 		@ApiResponse(responseCode = "200", description = "FCM 토큰 저장 성공")
 	})
 	ResponseEntity<Void> registerFcmToken(
-		@PathVariable Long darakbangId,
 		@LoginMember Member member,
 		@Valid @RequestBody FcmTokenSaveRequest fcmTokenSaveRequest
 	);
@@ -31,7 +30,7 @@ public interface NotificationSwagger {
 		@ApiResponse(responseCode = "200", description = "알림 조회 성공!")
 	})
 	ResponseEntity<RestResponse<NotificationFindAllResponses>> findAllMyNotification(
-		@PathVariable Long darakbangId,
-		@LoginMember Member member
+		@LoginMember Member member,
+		@PathVariable Long darakbangId
 	);
 }

--- a/backend/src/main/java/mouda/backend/notification/domain/MemberNotification.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/MemberNotification.java
@@ -23,13 +23,17 @@ public class MemberNotification {
 	@Column(nullable = false)
 	private long memberId;
 
+	@Column(nullable = false)
+	private long darakbangId;
+
 	@ManyToOne
 	@JoinColumn(nullable = false)
 	private MoudaNotification moudaNotification;
 
 	@Builder
-	public MemberNotification(long memberId, MoudaNotification moudaNotification) {
+	public MemberNotification(long memberId, long darakbangId, MoudaNotification moudaNotification) {
 		this.memberId = memberId;
+		this.darakbangId = darakbangId;
 		this.moudaNotification = moudaNotification;
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/repository/MemberNotificationRepository.java
+++ b/backend/src/main/java/mouda/backend/notification/repository/MemberNotificationRepository.java
@@ -8,5 +8,5 @@ import mouda.backend.notification.domain.MemberNotification;
 
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
 
-	List<MemberNotification> findAllByMemberId(Long memberId);
+	List<MemberNotification> findAllByMemberIdAndDarakbangId(Long memberId, Long darakbangId);
 }

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -46,12 +46,13 @@ public class NotificationService {
 		fcmTokenRepository.save(fcmToken);
 	}
 
-	public void notifyToMember(MoudaNotification moudaNotification, Long memberId) {
+	public void notifyToMember(MoudaNotification moudaNotification, Long memberId, Long darakbangId) {
 		MoudaNotification notification = moudaNotificationRepository.save(moudaNotification);
 
 		if (notification.getType() != NotificationType.NEW_CHAT) {
 			memberNotificationRepository.save(MemberNotification.builder()
 				.memberId(memberId)
+				.darakbangId(darakbangId)
 				.moudaNotification(notification)
 				.build());
 		}
@@ -60,35 +61,37 @@ public class NotificationService {
 		sendNotificationToAll(notification, tokens);
 	}
 
-	public void notifyToAllMembers(MoudaNotification moudaNotification) {
+	public void notifyToAllMembers(MoudaNotification moudaNotification, Long darakbangId) {
 		List<Long> allMemberId = fcmTokenRepository.findAllMemberId();
 
-		notifyToMembers(moudaNotification, allMemberId);
+		notifyToMembers(moudaNotification, allMemberId, darakbangId);
 	}
 
-	public void notifyToAllExceptMember(MoudaNotification moudaNotification, Long exceptMemberId) {
+	public void notifyToAllExceptMember(MoudaNotification moudaNotification, Long exceptMemberId, Long darakbangId) {
 		List<Long> allMemberId = fcmTokenRepository.findAllMemberId().stream()
 			.filter(memberId -> !Objects.equals(memberId, exceptMemberId))
 			.toList();
 
-		notifyToMembers(moudaNotification, allMemberId);
+		notifyToMembers(moudaNotification, allMemberId, darakbangId);
 	}
 
-	public void notifyToAllExceptMember(MoudaNotification moudaNotification, List<Long> exceptMemberIds) {
+	public void notifyToAllExceptMember(MoudaNotification moudaNotification, List<Long> exceptMemberIds,
+		Long darakbangId) {
 		List<Long> allMemberId = fcmTokenRepository.findAllMemberId().stream()
 			.filter(memberId -> !exceptMemberIds.contains(memberId))
 			.toList();
 
-		notifyToMembers(moudaNotification, allMemberId);
+		notifyToMembers(moudaNotification, allMemberId, darakbangId);
 	}
 
-	public void notifyToMembers(MoudaNotification moudaNotification, List<Long> memberIds) {
+	public void notifyToMembers(MoudaNotification moudaNotification, List<Long> memberIds, Long darakbangId) {
 		MoudaNotification notification = moudaNotificationRepository.save(moudaNotification);
 
 		if (notification.getType() != NotificationType.NEW_CHAT) {
 			memberNotificationRepository.saveAll(memberIds.stream()
 				.map(memberId -> MemberNotification.builder()
 					.memberId(memberId)
+					.darakbangId(darakbangId)
 					.moudaNotification(notification)
 					.build())
 				.toList());
@@ -135,8 +138,9 @@ public class NotificationService {
 		return result;
 	}
 
-	public NotificationFindAllResponses findAllMyNotifications(Member member) {
-		List<NotificationFindAllResponse> responses = memberNotificationRepository.findAllByMemberId(member.getId())
+	public NotificationFindAllResponses findAllMyNotifications(Member member, Long darakbangId) {
+		List<NotificationFindAllResponse> responses = memberNotificationRepository.findAllByMemberIdAndDarakbangId(
+				member.getId(), darakbangId)
 			.stream()
 			.map(MemberNotification::getMoudaNotification)
 			.map(NotificationFindAllResponse::from)

--- a/backend/src/test/java/mouda/backend/IgnoreNotificationTest.java
+++ b/backend/src/test/java/mouda/backend/IgnoreNotificationTest.java
@@ -17,10 +17,10 @@ public class IgnoreNotificationTest {
 
 	@BeforeEach
 	void setUp() {
-		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyLong());
-		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyList());
-		doNothing().when(notificationService).notifyToAllMembers(any());
-		doNothing().when(notificationService).notifyToMember(any(), any());
-		doNothing().when(notificationService).notifyToMembers(any(), any());
+		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyLong(), anyLong());
+		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyList(), anyLong());
+		doNothing().when(notificationService).notifyToAllMembers(any(), anyLong());
+		doNothing().when(notificationService).notifyToMember(any(), any(), anyLong());
+		doNothing().when(notificationService).notifyToMembers(any(), any(), anyLong());
 	}
 }

--- a/backend/src/test/java/mouda/backend/chat/service/ChatServiceTest.java
+++ b/backend/src/test/java/mouda/backend/chat/service/ChatServiceTest.java
@@ -75,7 +75,7 @@ class ChatServiceTest extends DarakbangSetUp {
 		chamyoRepository.save(new Chamyo(moim, darakbangHogee, MoimRole.MOIMER));
 
 		// when
-		ChatFindUnloadedResponse unloadedChats = chatService.findUnloadedChats(0L, moim.getId(), darakbangHogee);
+		ChatFindUnloadedResponse unloadedChats = chatService.findUnloadedChats(moim.getId(), 0L, darakbangHogee);
 
 		// then
 		assertThat(unloadedChats.chats()).hasSize(0);

--- a/backend/src/test/java/mouda/backend/moim/service/MoimServiceTest.java
+++ b/backend/src/test/java/mouda/backend/moim/service/MoimServiceTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

새로 추가된 다락방 기능을 알림에 반영했어요.

## 이슈 ID는 무엇인가요?

- close #386 

## 설명

- [x] 알림을 보낼떄 DarakbangMember 테이블의 id(PK)값이 아닌 Member 테이블의 id를 넣도록 수정
- [x] 테스트에서 FirebaseApp 중복 초기화 방지를 위한 코드 추가(FirebaseConfig)
- [x] 회원 알림 저장시 다락방 ID를 함께 저장하도록 수정

## 질문 혹은 공유 사항 (Optional)

**DarakbangMember와 Member의 관계를 조금 더 명확히 할 필요가 있습니다**. 적어도 DarakbangMember 필드 및 변수명이라도 darakbangMember로 명확히 할 필요가 있을 것 같아요.
로그인과 알림에서는 Member를 사용하는데, 다른 도메인에서는 DarakbangMember를 사용하다보니 Member의 id값을 얻으려면 getMember().getMember().getId() 로 불러와야 해요. Repository에서 Query로 작성한 코드에 대해서는 디버깅도 무지 어렵습니다..(같은 타입이라 컴파일 오류도 안나고 알림 기능은 테스트도 불가능해서 대형사고 가능성이 매우 커요..!!)

일단은 기존 형식 그대로 사용했기에.. 최대한 꼼꼼하게 확인했고 검토도 2번 해서 올립니다..


