### PR TITLE
참여하지 않은 경우 예외 던지는 로직 제거

### DIFF
--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -45,7 +45,7 @@ public class ChamyoService {
 		Optional<Chamyo> chamyoOptional = chamyoRepository.findByMoimIdAndDarakbangMemberId(moimId,
 			darakbangMember.getId());
 		chamyoOptional.ifPresent(chamyo -> {
-			if (chamyo.getMoim().inNotDarakbang(darakbangId)) {
+			if (chamyo.getMoim().isNotInDarakbang(darakbangId)) {
 				throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND);
 			}
 		});
@@ -59,7 +59,7 @@ public class ChamyoService {
 	public ChamyoFindAllResponses findAllChamyo(Long darakbangId, Long moimId) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND);
 		}
 		List<ChamyoFindAllResponse> responses = chamyoRepository.findAllByMoimId(moimId)
@@ -73,7 +73,7 @@ public class ChamyoService {
 	public void chamyoMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND);
 		}
 		validateCanChamyoMoim(moim, darakbangMember);
@@ -124,7 +124,7 @@ public class ChamyoService {
 	public void cancelChamyo(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ChamyoException(HttpStatus.NOT_FOUND, ChamyoErrorMessage.MOIM_NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND);
 		}
 		validateCanCancelChamyo(moim, darakbangMember);

--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -44,10 +44,11 @@ public class ChamyoService {
 	public MoimRoleFindResponse findMoimRole(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Optional<Chamyo> chamyoOptional = chamyoRepository.findByMoimIdAndDarakbangMemberId(moimId,
 			darakbangMember.getId());
-
-		chamyoOptional
-			.map(chamyo -> chamyo.getMoim().inNotDarakbang(darakbangId))
-			.orElseThrow(() -> new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND));
+		chamyoOptional.ifPresent(chamyo -> {
+			if (chamyo.getMoim().inNotDarakbang(darakbangId)) {
+				throw new ChamyoException(HttpStatus.BAD_REQUEST, ChamyoErrorMessage.MOIM_NOT_FOUND);
+			}
+		});
 
 		MoimRole moimRole = chamyoOptional.map(Chamyo::getMoimRole).orElse(MoimRole.NON_MOIMEE);
 

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -53,7 +53,7 @@ public class ChatService {
 
 	public void createChat(Long darakbangId, ChatCreateRequest chatCreateRequest, DarakbangMember darakbangMember) {
 		Moim moim = findMoimByMoimId(chatCreateRequest.moimId(), darakbangId);
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.MOIM_NOT_FOUND);
 		}
 		findChamyoByMoimIdAndMemberId(chatCreateRequest.moimId(), darakbangMember.getId());
@@ -187,7 +187,7 @@ public class ChatService {
 	private Moim findMoimByMoimId(long moimId, long darabangId) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.MOIM_NOT_FOUND));
-		if (moim.inNotDarakbang(darabangId)) {
+		if (moim.isNotInDarakbang(darabangId)) {
 			throw new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.MOIM_NOT_FOUND);
 		}
 		return moim;

--- a/backend/src/main/java/mouda/backend/moim/domain/Moim.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Moim.java
@@ -203,7 +203,7 @@ public class Moim {
 		this.isChatOpened = true;
 	}
 
-	public boolean inNotDarakbang(Long darakbangId) {
+	public boolean isNotInDarakbang(long darakbangId) {
 		return this.darakbangId != darakbangId;
 	}
 }

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -95,7 +95,7 @@ public class MoimService {
 	public MoimDetailsFindResponse findMoimDetails(long darakbangId, long moimId) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 
@@ -119,7 +119,7 @@ public class MoimService {
 	public void deleteMoim(long darakbangId, long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 		validateCanDeleteMoim(moim, darakbangMember);
@@ -144,7 +144,7 @@ public class MoimService {
 	) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 
@@ -180,7 +180,7 @@ public class MoimService {
 	public void completeMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 		validateCanCompleteMoim(moim, darakbangMember);
@@ -219,7 +219,7 @@ public class MoimService {
 	public void cancelMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 		validateCanCancelMoim(moim, darakbangMember);
@@ -239,7 +239,7 @@ public class MoimService {
 	public void reopenMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 		validateCanReopenMoim(moim, darakbangMember);
@@ -277,7 +277,7 @@ public class MoimService {
 	public void editMoim(Long darakbangId, MoimEditRequest request, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(request.moimId())
 			.orElseThrow(() -> new MoimException(HttpStatus.NOT_FOUND, MoimErrorMessage.NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new MoimException(HttpStatus.BAD_REQUEST, MoimErrorMessage.NOT_FOUND);
 		}
 		validateCanEditMoim(moim, darakbangMember);

--- a/backend/src/main/java/mouda/backend/please/domain/Please.java
+++ b/backend/src/main/java/mouda/backend/please/domain/Please.java
@@ -60,7 +60,7 @@ public class Please {
 		return authorId != memberId;
 	}
 
-	public boolean inNotDarakbang(Long darakbangId) {
+	public boolean isNotInDarakbang(long darakbangId) {
 		return this.darakbangId != darakbangId;
 	}
 }

--- a/backend/src/main/java/mouda/backend/please/service/InterestService.java
+++ b/backend/src/main/java/mouda/backend/please/service/InterestService.java
@@ -25,7 +25,7 @@ public class InterestService {
 	public void updateInterest(Long darakbangId, DarakbangMember darakbangMember, InterestUpdateRequest request) {
 		Please please = pleaseRepository.findById(request.pleaseId())
 			.orElseThrow(() -> new PleaseException(HttpStatus.NOT_FOUND, PleaseErrorMessage.NOT_FOUND));
-		if (please.inNotDarakbang(darakbangId)) {
+		if (please.isNotInDarakbang(darakbangId)) {
 			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.PLEASE_NOT_IN_DARAKBANG);
 		}
 

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -35,7 +35,7 @@ public class PleaseService {
 	public void deletePlease(Long darakbangId, Long pleaseId, DarakbangMember darakbangMember) {
 		Please please = pleaseRepository.findById(pleaseId)
 			.orElseThrow(() -> new PleaseException(HttpStatus.NOT_FOUND, PleaseErrorMessage.NOT_FOUND));
-		if (please.inNotDarakbang(darakbangId)) {
+		if (please.isNotInDarakbang(darakbangId)) {
 			throw new PleaseException(HttpStatus.BAD_REQUEST, PleaseErrorMessage.PLEASE_NOT_IN_DARAKBANG);
 		}
 		if (please.isNotAuthor(darakbangMember.getId())) {

--- a/backend/src/main/java/mouda/backend/zzim/service/ZzimService.java
+++ b/backend/src/main/java/mouda/backend/zzim/service/ZzimService.java
@@ -26,7 +26,7 @@ public class ZzimService {
 	public ZzimCheckResponse checkZzimByMember(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ZzimException(HttpStatus.NOT_FOUND, ZzimErrorMessage.MOIN_NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ZzimException(HttpStatus.BAD_REQUEST, ZzimErrorMessage.MOIN_NOT_FOUND);
 		}
 
@@ -38,7 +38,7 @@ public class ZzimService {
 	public void updateZzim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
 		Moim moim = moimRepository.findById(moimId)
 			.orElseThrow(() -> new ZzimException(HttpStatus.NOT_FOUND, ZzimErrorMessage.MOIN_NOT_FOUND));
-		if (moim.inNotDarakbang(darakbangId)) {
+		if (moim.isNotInDarakbang(darakbangId)) {
 			throw new ZzimException(HttpStatus.BAD_REQUEST, ZzimErrorMessage.MOIN_NOT_FOUND);
 		}
 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

참여하지 않은 모임에서 역할 조회시 예외를 던지는 버그를 수정합니다.

## 이슈 ID는 무엇인가요?

- #401 

## 설명

참여하지 않은 유저의 경우 `NON_MOIMEE`를 반환합니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
