### PR TITLE
알림에서 에러 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -183,6 +183,9 @@ public class NotificationService {
 	}
 
 	private boolean isInvalidTokenErrorCode(SendResponse sendResponse) {
+		if (sendResponse.isSuccessful()) {
+			return false;
+		}
 		MessagingErrorCode errorCode = sendResponse.getException().getMessagingErrorCode();
 		return errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
 	}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

알림 응답에서 성공인 경우도 getException을 호출해 NPE 가 발생하고 있습니다.
알림 응답에서 성공인 경우 예외 꺼내지 않도록 수정했습니다.

## 이슈 ID는 무엇인가요?

- #418 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
