### PR TITLE
파이어베이스 연동이 되지 않는 문제 해결 

### DIFF
--- a/backend/src/main/java/mouda/backend/config/FirebaseConfig.java
+++ b/backend/src/main/java/mouda/backend/config/FirebaseConfig.java
@@ -21,9 +21,7 @@ public class FirebaseConfig {
 			FirebaseOptions options = new FirebaseOptions.Builder()
 				.setCredentials(GoogleCredentials.fromStream(serviceAccount))
 				.build();
-			if (FirebaseApp.getApps().isEmpty()) {
-				FirebaseApp.initializeApp(options);
-			}
+			FirebaseApp.initializeApp(options);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

FirebaseApp을 불러오지 못하는 오류 해결

## 이슈 ID는 무엇인가요?

- close #428 

## 설명

FirebaseApp을 시작할 때, `FirebaseApp.getApps().isEmpty()`로 기존에 실행 된 FirebaseApp이 있는지 조회하고 있었음. 여기에 조회가 되긴 하지만 DEFAULT라는 이름의 FIrebaseApp이 존재하지 않아 발생하는 오류로 추정됨.

## 질문 혹은 공유 사항 (Optional)


