### PR TITLE
폴링 방식으로 보낸 채팅 요청이 모두 로그에 찍히는 현상 해결 

### DIFF
--- a/backend/src/main/java/mouda/backend/aop/logging/ExceptRequestLogging.java
+++ b/backend/src/main/java/mouda/backend/aop/logging/ExceptRequestLogging.java
@@ -1,0 +1,12 @@
+package mouda.backend.aop.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExceptRequestLogging {
+
+}

--- a/backend/src/main/java/mouda/backend/aop/logging/RequestLoggingAspect.java
+++ b/backend/src/main/java/mouda/backend/aop/logging/RequestLoggingAspect.java
@@ -2,6 +2,7 @@ package mouda.backend.aop.logging;
 
 import static java.util.stream.Collectors.*;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
 import org.aspectj.lang.JoinPoint;
@@ -31,6 +32,13 @@ public class RequestLoggingAspect {
 	@Before("allController()")
 	public void logController(JoinPoint joinPoint) {
 		HttpServletRequest request = getHttpServletRequest();
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Method method = signature.getMethod();
+		if (method.isAnnotationPresent(ExceptRequestLogging.class)) {
+			return;
+		}
+
 		String uri = request.getRequestURI();
 		String httpMethod = request.getMethod();
 		String queryParameters = getQueryParameters(request);

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -59,6 +59,7 @@ public class ChatController implements ChatSwagger {
 	}
 
 	@Override
+	@ExceptRequestLogging
 	@GetMapping("/preview")
 	public ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
 		@PathVariable Long darakbangId,

--- a/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/controller/ChatController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import mouda.backend.aop.logging.ExceptRequestLogging;
 import mouda.backend.chat.dto.request.ChatCreateRequest;
 import mouda.backend.chat.dto.request.DateTimeConfirmRequest;
 import mouda.backend.chat.dto.request.LastReadChatRequest;
@@ -43,6 +44,7 @@ public class ChatController implements ChatSwagger {
 	}
 
 	@Override
+	@ExceptRequestLogging
 	@GetMapping
 	public ResponseEntity<RestResponse<ChatFindUnloadedResponse>> findUnloadedChats(
 		@PathVariable Long darakbangId,


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->


## 이슈 ID는 무엇인가요?

- #432 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

테바가 추가한 AOP 코드에 어노테이션을 추가하여, 채팅 조회 (폴링) 시 요청 로그가 찍히지 않도록 수정하였습니다.
추가) 채팅방 목록 조회 시 폴링 로그를 제외하였습니다.


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
