### PR TITLE
채팅방 및 해주세요 페이지 정렬 추가

### DIFF
--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -1,5 +1,7 @@
 package mouda.backend.chat.service;
 
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -148,6 +150,7 @@ public class ChatService {
 			.findAllByDarakbangMemberIdAndMoim_DarakbangId(darakbangMember.getId(), darakbangId)
 			.stream()
 			.filter(chamyo -> chamyo.getMoim().isChatOpened())
+			.sorted(getChatComparatorByLastCreatedAt())
 			.map(this::getChatPreviewResponse)
 			.toList();
 
@@ -162,6 +165,13 @@ public class ChatService {
 		String lastContent = lastChat.map(Chat::getContent).orElse("");
 
 		return ChatPreviewResponse.toResponse(chamyo, currentPeople, lastContent);
+	}
+
+	private Comparator<Chamyo> getChatComparatorByLastCreatedAt() {
+		return Comparator.comparing(chamyo ->
+			chatRepository.findFirstByMoimIdOrderByIdDesc(chamyo.getMoim().getId())
+				.map(chat -> LocalDateTime.of(chat.getDate(), chat.getTime()))
+				.orElse(null), Comparator.nullsLast(Comparator.reverseOrder()));
 	}
 
 	public void createLastChat(

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -168,10 +168,11 @@ public class ChatService {
 	}
 
 	private Comparator<Chamyo> getChatComparatorByLastCreatedAt() {
-		return Comparator.comparing(chamyo ->
-			chatRepository.findFirstByMoimIdOrderByIdDesc(chamyo.getMoim().getId())
-				.map(chat -> LocalDateTime.of(chat.getDate(), chat.getTime()))
-				.orElse(null), Comparator.nullsLast(Comparator.reverseOrder()));
+		return Comparator.<Chamyo, LocalDateTime>comparing(chamyo ->
+				chatRepository.findFirstByMoimIdOrderByIdDesc(chamyo.getMoim().getId())
+					.map(chat -> LocalDateTime.of(chat.getDate(), chat.getTime()))
+					.orElse(null), Comparator.nullsLast(Comparator.reverseOrder()))
+			.thenComparing(Chamyo::getId, Comparator.naturalOrder());
 	}
 
 	public void createLastChat(

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -172,7 +172,7 @@ public class ChatService {
 				chatRepository.findFirstByMoimIdOrderByIdDesc(chamyo.getMoim().getId())
 					.map(chat -> LocalDateTime.of(chat.getDate(), chat.getTime()))
 					.orElse(null), Comparator.nullsLast(Comparator.reverseOrder()))
-			.thenComparing(Chamyo::getId, Comparator.naturalOrder());
+			.thenComparing(chamyo -> chamyo.getMoim().getId(), Comparator.naturalOrder());
 	}
 
 	public void createLastChat(

--- a/backend/src/main/java/mouda/backend/please/service/PleaseService.java
+++ b/backend/src/main/java/mouda/backend/please/service/PleaseService.java
@@ -1,5 +1,6 @@
 package mouda.backend.please.service;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -56,6 +57,7 @@ public class PleaseService {
 					long interestCount = interestRepository.countByPleaseId(please.getId());
 					return PleaseFindAllResponse.toResponse(please, isInterested, interestCount);
 				})
+				.sorted(Comparator.comparing(PleaseFindAllResponse::interestCount).reversed().thenComparing(PleaseFindAllResponse::pleaseId))
 				.toList());
 	}
 }

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -168,7 +168,7 @@ class PleaseServiceTest extends DarakbangSetUp {
 
 			PleaseFindAllResponses pleaseFindAllResponses = pleaseService.findAllPlease(
 				darakbang.getId(), darakbangHogee);
-			assertThat(pleaseFindAllResponses.pleases()).extracting("isInterested").containsExactly(false, true);
+			assertThat(pleaseFindAllResponses.pleases()).extracting("isInterested").containsExactly(true, false);
 		}
 	}
 }

--- a/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
+++ b/backend/src/test/java/mouda/backend/please/service/PleaseServiceTest.java
@@ -45,6 +45,48 @@ class PleaseServiceTest extends DarakbangSetUp {
 			assertThat(pleaseService.findAllPlease(darakbang.getId(), darakbangHogee).pleases()).hasSize(1);
 			assertThat(pleaseService.findAllPlease(mouda.getId(), moudaHogee).pleases()).hasSize(0);
 		}
+
+		@DisplayName("해주세요 목록 조회시 관심이 많은 순서대로 조회하고, 관심이 같다면 생성된 순서대로 조회한다.")
+		@Test
+		void findAllPlease_isSortedByInterestCount() {
+			Please please1 = pleaseRepository.save(Please.builder()
+				.authorId(1L)
+				.darakbangId(darakbang.getId())
+				.title("해주세요1~~")
+				.description("해주세요1 해줘~~")
+				.build());
+
+			Please please2 = pleaseRepository.save(Please.builder()
+				.authorId(1L)
+				.darakbangId(darakbang.getId())
+				.title("해주세요2~~")
+				.description("해주세요2 해줘~~")
+				.build());
+
+			Please please3 = pleaseRepository.save(Please.builder()
+				.authorId(1L)
+				.darakbangId(darakbang.getId())
+				.title("해주세요3~~")
+				.description("해주세요3 해줘~~")
+				.build());
+
+			interestService.updateInterest(darakbang.getId(), darakbangHogee,
+				new InterestUpdateRequest(please1.getId(), true));
+
+			interestService.updateInterest(darakbang.getId(), darakbangHogee,
+				new InterestUpdateRequest(please2.getId(), true));
+			interestService.updateInterest(darakbang.getId(), darakbangAnna,
+				new InterestUpdateRequest(please2.getId(), true));
+
+			interestService.updateInterest(darakbang.getId(), darakbangHogee,
+				new InterestUpdateRequest(please3.getId(), true));
+
+			PleaseFindAllResponses pleaseFindAllResponses = pleaseService.findAllPlease(
+				darakbang.getId(), darakbangHogee);
+
+			assertThat(pleaseFindAllResponses.pleases()).extracting("pleaseId")
+				.containsExactly(please2.getId(), please1.getId(), please3.getId());
+		}
 	}
 
 	@DisplayName("해주세요 생성 테스트")


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

채팅방 및 해주세요 페이지 정렬 기능 추가

## 이슈 ID는 무엇인가요?

- #499 

## 설명

- [x] 채팅방은 가장 최근에 메시지가 온 순서대로 정렬한다.
    - [x] 채팅방만 만들고 채팅을 보내지 않은 경우는 가장 아래에 위치한다.
    - [x] 같은 조건이면 모임 생성 순서(Moim.getId())로 정렬한다.

- [x] 해주세요 페이지는 관심이 가장 많은 순서대로 정렬한다.
    - [x] 관심 수가 같은 경우에는 생성 순서(Please.getId())로 정렬한다.


## 질문 혹은 공유 사항 (Optional)

우리끼리 할 때는 잘 몰랐는데, 런칭 페스티벌에서 많은 사람이랑 같이 써보니 가장 불편하게 느껴지더라구요. 
(특히나 모우다 팀 회식 모임 만들고 채팅방 갈때 맨 아래로 스크롤 해야하는게 제일 불편했음)

추가적으로 채팅방에서 아직 안 읽은 채팅방은 별도로(빨간불 같이..?) 표시했으면 좋겠습니다.
(예시 사진)

<img width="464" alt="스크린샷 2024-08-25 오후 6 29 15" src="https://github.com/user-attachments/assets/7437a840-55d3-4825-a7dd-e33d0de140a1">


로컬에서 돌렸을 때 기능 작동하는 것 확인했고, 변경사항이 많지 않아서 폐기하기 어렵지 않으니 생각해보시고 편하게들 의견 주셔요~😄😄




