### PR TITLE
Swagger-ui에서의 CORS 에러 해결

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: native
+
 spring:
   profiles:
     active:
@@ -8,7 +11,6 @@ security:
     token:
       secret-key: kksangdolbabokksangdolbabokksangdolbabokksangdolbabokksangdolbabokksangdolbabo
       expire-length: 3600000
-
 url:
   moim: /darakbang/%d/moim/%d
   chat: /darakbang/%d/chat/%d


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

Swagger-UI에서 발생하는 CORS 에러를 해결합니다.

## 이슈 ID는 무엇인가요?

- close #505 

## 설명

- [x] application.yml에 froxy header를 사용하는 설정 정보 추가

## 질문 혹은 공유 사항 (Optional)

### 원인
1. 현재 springboot 서버는 Nginx를 통해 포워딩 되고 있습니다.(리버스 프록시)

2. 프록시 서버에서 백엔드 서버로 클라이언트 요청을 전달할 때는 헤더에 클라이언트의 요청 프로토콜을 담아 전달합니다.(X-Forwarded-Proto 헤더, 요청이 https이면 https가 담김) 
- 이건 nginx 내부에서 설정할 수 있고, 물론 안 보낼수도 있음.

3. swagger-ui는 HttpServletRequest로부터 이 프로토콜을 읽어 server를 지정하는데, X-Forwarded-Proto 헤더가 표준 헤더가 아니다보니 이 값을 처리를 못 하고 http로 값을 지정하고 있었습니다.

<img width="345" alt="스크린샷 2024-08-27 오전 12 32 11" src="https://github.com/user-attachments/assets/d5d9cb5c-e0f7-4cc8-8701-266810a56b65">

4. 그래서 swagger-ui를 보면 위 사진처럼 서버가 http://mouda.site..로 지정되는데 이 경로에 대해서는 CORS 설정이 되어있지 않기에 발생하는 오류로 확인됩니다.

### 해결 방안
CorsConfig에 http://mouda.site를 추가하거나, SwaggerConfig에서 server를 지정해 줘도 해결되는 문제이나, 추후에 클라이언트 요청 정보를 확인할 경우도 있다고 판단되어 프록시 서버에서 전달하는 헤더들을 처리하는 설정 정보를 추가하였습니다. 


간단하게 풀어쓰기 어려운 주제네요.. Nginx를 공부하는 과정에서 알게 된건데 기회가 되면 자세히 설명할 시간을 가져볼게요! 자세한 내용은 [Spring 공식 문서](https://docs.spring.io/spring-framework/reference/web/webmvc/filters.html#forwarded-headers)
를 참고해주세요. 😄

