### PR TITLE
OpenAPI Specification와 Code Generator를 사용한 API 명세서 관리 간편화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,10 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.openapi.generator' version '7.8.0'
 }
 
 group = 'mouda'
@@ -21,6 +24,46 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+sourceSets {
+    main {
+        java.srcDir("$buildDir/generated")
+    }
+}
+
+ext {
+    dirs = [
+            'docs'           : "$rootDir/docs",
+            'openApiGenerate': "$rootDir/docs/swagger"
+    ]
+
+    openApiPackages = ['openapi.api', 'openapi.invoker', 'openapi.model']
+
+    generateOpenApiTasks = fileTree(dirs.get("docs"))
+            .files
+            .findAll { file -> file.name.endsWith('.json') }
+            .collect(file -> createOpenApiGenerateTask(file.name))
+}
+
+def createOpenApiGenerateTask(String fileName) {
+    tasks.register("openApiGenerate_$fileName", GenerateTask) {
+        getGeneratorName().set("spring")
+        getInputSpec().set("${dirs["docs"]}/$fileName")
+        getOutputDir().set(dirs.get("openApiGenerate") as String)
+        getApiPackage().set(openApiPackages[0] as String)
+        getInvokerPackage().set(openApiPackages[1] as String)
+        getModelPackage().set(openApiPackages[2] as String)
+        getConfigOptions().set(
+                [
+                        "dateLibrary"    : "spring",
+                        "useSpringBoot3" : "true",
+                        "useTags"        : "true",
+                        "openApiNullable": "false",
+                        "interfaceOnly"  : "true"
+                ]
+        )
+    }
 }
 
 dependencies {
@@ -52,6 +95,58 @@ dependencies {
 
     // notification
     implementation 'com.google.firebase:firebase-admin:9.3.0'
+}
+
+tasks.named("compileJava") {
+    dependsOn("cleanGeneratedDirectory")
+}
+
+tasks.register("cleanGeneratedDirectory") {
+    doFirst {
+        println("Cleaning generated directory...")
+    }
+    doLast {
+        def openApiGenerateDir = file(dirs.get('openApiGenerate'))
+        if (openApiGenerateDir.exists()) {
+            openApiGenerateDir.deleteDir()
+            println "Directory ${openApiGenerateDir} deleted."
+        } else {
+            println "Directory ${openApiGenerateDir} does not exist."
+        }
+    }
+    dependsOn("moveGeneratedSources")
+}
+
+tasks.register("moveGeneratedSources") {
+    doFirst {
+        println("Moving generated sources...")
+    }
+
+    doLast {
+        openApiPackages.each { packageName ->
+            def packagePath = packageName.replace(".", "/")
+            def originDir = file("${dirs.get('openApiGenerate')}/src/main/java/${packagePath}")
+            def destinationDir = file("$buildDir/generated/${packagePath}")
+            copy {
+                originDir = file("${dirs.get('openApiGenerate')}/src/main/java/${packagePath}")
+                destinationDir = file("$buildDir/generated/${packagePath}")
+                from originDir
+                into destinationDir
+            }
+        }
+        println 'Generated sources moved.'
+    }
+    dependsOn("createOpenApi")
+}
+
+tasks.register("createOpenApi") {
+    doFirst {
+        println("Creating Code By OpenAPI...")
+    }
+    doLast {
+        println("OpenAPI Code created.")
+    }
+    dependsOn(generateOpenApiTasks)
 }
 
 tasks.named('test') {

--- a/backend/docs/contract.json
+++ b/backend/docs/contract.json
@@ -1,0 +1,2382 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "https://dev.mouda.site",
+      "description": "Generated server url"
+    }
+  ],
+  "security": [
+    {
+      "Bearer Authorization": []
+    }
+  ],
+  "paths": {
+    "/v1/notification/registerrrr": {
+      "post": {
+        "tags": [
+          "notification-controller"
+        ],
+        "summary": "FCM 토큰을 저장합니다.",
+        "description": "알림 허용시 FCM 토큰을 저장합니다.",
+        "operationId": "registerFcmToken",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FcmTokenSaveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "FCM 토큰 저장 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang": {
+      "post": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 생성",
+        "description": "다락방을 생성한다.",
+        "operationId": "createDarakbang",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DarakbangCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "다락방 생성 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "이미 존재하는 다락방 이름입니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/zzim": {
+      "post": {
+        "tags": [
+          "zzim-controller"
+        ],
+        "summary": "모임 찜하기",
+        "description": "해당 모임을 찜한다.",
+        "operationId": "updateZzim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ZzimUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "모임 찜하기 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/please": {
+      "get": {
+        "tags": [
+          "please-controller"
+        ],
+        "summary": "해주세요 목록 조회",
+        "description": "해주세요 목록을 조회한다.",
+        "operationId": "findAllPlease",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "해주세요 목록 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponsePleaseFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "please-controller"
+        ],
+        "summary": "해주세요 생성",
+        "description": "해주세요를 생성한다.",
+        "operationId": "createPlease",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PleaseCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "해주세요 생성 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim": {
+      "get": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 전체 조회",
+        "description": "모든 모임을 조회한다.",
+        "operationId": "findAllMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모임 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMoimFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 생성",
+        "description": "모임을 생성한다.",
+        "operationId": "createMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoimCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "모임 생성 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 수정",
+        "description": "해당하는 id의 모임을 수정한다.",
+        "operationId": "editMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoimEditRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "모임 수정 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/{moimId}": {
+      "get": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 상세 조회",
+        "description": "모임 상세 조회한다.",
+        "operationId": "findMoimDetails",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모임 상세 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMoimDetailsFindResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "댓글 작성",
+        "description": "해당하는 id의 모임에 댓글을 생성한다.",
+        "operationId": "createComment",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommentCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "댓글 생성 성공!"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 삭제",
+        "description": "해당하는 id의 모임을 삭제한다.",
+        "operationId": "deleteMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모임 삭제 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/interest": {
+      "post": {
+        "tags": [
+          "interest-controller"
+        ],
+        "summary": "관심 상태 변경",
+        "description": "관심 상태를 변경한다.",
+        "operationId": "updateInterest",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InterestUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "관심 상태 변경 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat": {
+      "get": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "채팅 조회",
+        "description": "아직 조회되지 않은 채팅 내역을 조회한다.",
+        "operationId": "findUnloadedChats",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "recentChatId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "채팅 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseChatFindUnloadedResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "채팅 생성",
+        "description": "한 건의 채팅 메시지를 보낸다.",
+        "operationId": "createChat",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "채팅 생성 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat/place": {
+      "post": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "장소 확정",
+        "description": "작성자가 장소를 확정하는 채팅을 전송합니다.",
+        "operationId": "confirmPlace",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaceConfirmRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "장소 확정 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat/last": {
+      "post": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "마지막 읽은 채팅 저장",
+        "description": "마지막 읽은 채팅을 저장한다.",
+        "operationId": "createLastReadChatId",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LastReadChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "마지막 채팅 저장 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat/datetime": {
+      "post": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "날짜 시간 확정",
+        "description": "작성자가 날짜와 시간을 확정하는 채팅을 전송합니다.",
+        "operationId": "confirmDateTime",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DateTimeConfirmRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "날짜 시간 확정 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chamyo": {
+      "post": {
+        "tags": [
+          "chamyo-controller"
+        ],
+        "summary": "모임 참여",
+        "description": "모임에 참여합니다.",
+        "operationId": "chamyoMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoimChamyoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "모임 참여 성공"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "chamyo-controller"
+        ],
+        "summary": "모임 참여 취소",
+        "description": "모임 참여를 취소합니다.",
+        "operationId": "cancelChamyo",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChamyoCancelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "모임 참여 취소 성공"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/entrance": {
+      "post": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 참여",
+        "description": "다락방에 참여한다.",
+        "operationId": "enterDarakbang",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DarakbangEnterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "다락방 참여 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "이미 존재하는 닉네임입니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "다락방이 존재하지 않습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLong"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/kakao/oauth": {
+      "post": {
+        "tags": [
+          "auth-controller"
+        ],
+        "summary": "로그인",
+        "description": "카카오 Oauth Code를 사용하여 로그인한다(accessToken 발급).",
+        "operationId": "loginKakaoOauth",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OauthRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "로그인 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseLoginResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/{moimId}/reopen": {
+      "patch": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모집 재개",
+        "description": "방장이 모집을 재개합니다.",
+        "operationId": "reopenMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모집 재개 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/{moimId}/complete": {
+      "patch": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모집 완료",
+        "description": "방장이 모집을 완료합니다.",
+        "operationId": "completeMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모집 완료 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/{moimId}/cancel": {
+      "patch": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "모임 취소",
+        "description": "방장이 모임을 취소합니다.",
+        "operationId": "cancelMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모임 취소 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat/open": {
+      "patch": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "채팅방 열기",
+        "description": "채팅방을 연다!",
+        "operationId": "openChatRoom",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "채팅방 열기 성공!"
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}": {
+      "get": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 이름 조회",
+        "description": "다락방 이름을 조회한다.",
+        "operationId": "findDarakbangName",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "다락방 이름 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangNameResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "다락방이 존재하지 않습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangNameResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/zzim/mine": {
+      "get": {
+        "tags": [
+          "zzim-controller"
+        ],
+        "summary": "찜 여부 조회",
+        "description": "해당 모임에 대한 회원의 찜 여부를 조회한다.",
+        "operationId": "checkZzimByMoimAndMember",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "찜 여부 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseZzimCheckResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/role": {
+      "get": {
+        "tags": [
+          "darakbang-member-controller"
+        ],
+        "summary": "다락방 멤버 권한 조회",
+        "description": "다락방 멤버 권한을 조회한다.",
+        "operationId": "findDarakbangMemberRole",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "다락방 멤버 권한 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangMemberRoleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/notification/mine": {
+      "get": {
+        "tags": [
+          "notification-controller"
+        ],
+        "summary": "모든 알림 조회",
+        "description": "회원의 모든 알림을 조회합니다.",
+        "operationId": "findAllMyNotification",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "알림 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseNotificationFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/zzim": {
+      "get": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "찜한 모임 목록 조회",
+        "description": "찜한 모임의 목록을 조회한다.",
+        "operationId": "findAllZzimedMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "찜한 모임 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMoimFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/moim/mine": {
+      "get": {
+        "tags": [
+          "moim-controller"
+        ],
+        "summary": "나의 모임 목록 조회",
+        "description": "내가 참여하는 모임의 목록을 조회한다.",
+        "operationId": "findAllMyMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "ALL",
+              "enum": [
+                "ALL",
+                "PAST",
+                "UPCOMING"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "나의 모임 목록 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMoimFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/members": {
+      "get": {
+        "tags": [
+          "darakbang-member-controller"
+        ],
+        "summary": "다락방 멤버 목록 조회",
+        "description": "다락방 멤버 목록을 조회한다.",
+        "operationId": "findAllDarakbangMembers",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "다락방 멤버 목록 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangMemberResponses"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "조회 권한이 없습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangMemberResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/member/mine": {
+      "get": {
+        "tags": [
+          "member-controller"
+        ],
+        "summary": "로그인 된 회원의 정보 조회",
+        "description": "로그인 된 회원의 정보를 조회합니다.",
+        "operationId": "findMyInfo",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMemberFindResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/code": {
+      "get": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 참여코드 조회",
+        "description": "참여한 다락방 참여코드를 조회한다.",
+        "operationId": "findInvitationCode",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "다락방 참여코드 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseInvitationCodeResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "조회 권한이 없습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseInvitationCodeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "다락방이 존재하지 않습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseInvitationCodeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chat/preview": {
+      "get": {
+        "tags": [
+          "chat-controller"
+        ],
+        "summary": "채팅방 목록 조회",
+        "description": "채팅방 목록을 조회한다.",
+        "operationId": "findChatPreviews",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "채팅방 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseChatPreviewResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chamyo/mine": {
+      "get": {
+        "tags": [
+          "chamyo-controller"
+        ],
+        "summary": "모임 참여 여부 조회",
+        "description": "현재 로그인된 회원의 모임 참여 여부를 조회합니다.",
+        "operationId": "findMoimRoleByMember",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모임 참여 여부 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseMoimRoleFindResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/chamyo/all": {
+      "get": {
+        "tags": [
+          "chamyo-controller"
+        ],
+        "summary": "모든 모임 참여자 조회",
+        "description": "모임에 참여한 모든 회원을 조회합니다.",
+        "operationId": "findAllChamyoByMoim",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "moimId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "모든 모임 참여자 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseChamyoFindAllResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/validation": {
+      "get": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 초대코드 유효성 검사",
+        "description": "다락방 초대코드 유효성을 검사한다.",
+        "operationId": "validateInvitationCode",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "다락방 초대코드 유효성 검사 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseCodeValidationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "유효하지 않은 초대코드입니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseCodeValidationResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/mine": {
+      "get": {
+        "tags": [
+          "darakbang-controller"
+        ],
+        "summary": "다락방 목록 조회",
+        "description": "참여한 다락방 목록을 조회한다.",
+        "operationId": "findAllMyDarakbangs",
+        "responses": {
+          "200": {
+            "description": "다락방 목록 조회 성공!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestResponseDarakbangResponses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/darakbang/{darakbangId}/please/{pleaseId}": {
+      "delete": {
+        "tags": [
+          "please-controller"
+        ],
+        "summary": "해주세요 삭제",
+        "description": "해주세요를 삭제한다.",
+        "operationId": "deletePlease",
+        "parameters": [
+          {
+            "name": "darakbangId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "pleaseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "해주세요 삭제 성공!"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FcmTokenSaveRequest": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          }
+        }
+      },
+      "DarakbangCreateRequest": {
+        "required": [
+          "name",
+          "nickname"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseLong": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ZzimUpdateRequest": {
+        "required": [
+          "moimId"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PleaseCreateRequest": {
+        "required": [
+          "description",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "LocalTime": {
+        "type": "object",
+        "properties": {
+          "hour": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minute": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "second": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "nano": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "MoimCreateRequest": {
+        "required": [
+          "maxPeople",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "time": {
+            "$ref": "#/components/schemas/LocalTime"
+          },
+          "place": {
+            "type": "string"
+          },
+          "maxPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "CommentCreateRequest": {
+        "required": [
+          "content"
+        ],
+        "type": "object",
+        "properties": {
+          "parentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "InterestUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "pleaseId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isInterested": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ChatCreateRequest": {
+        "required": [
+          "content",
+          "moimId"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "PlaceConfirmRequest": {
+        "required": [
+          "moimId",
+          "place"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "place": {
+            "type": "string"
+          }
+        }
+      },
+      "LastReadChatRequest": {
+        "required": [
+          "lastReadChatId",
+          "moimId"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastReadChatId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "DateTimeConfirmRequest": {
+        "required": [
+          "date",
+          "moimId",
+          "time"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "time": {
+            "$ref": "#/components/schemas/LocalTime"
+          }
+        }
+      },
+      "MoimChamyoRequest": {
+        "required": [
+          "moimId"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "DarakbangEnterRequest": {
+        "required": [
+          "nickname"
+        ],
+        "type": "object",
+        "properties": {
+          "nickname": {
+            "type": "string"
+          }
+        }
+      },
+      "OauthRequest": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          }
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseLoginResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/LoginResponse"
+          }
+        }
+      },
+      "MoimEditRequest": {
+        "required": [
+          "maxPeople",
+          "moimId",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "time": {
+            "$ref": "#/components/schemas/LocalTime"
+          },
+          "place": {
+            "type": "string"
+          },
+          "maxPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "DarakbangNameResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseDarakbangNameResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DarakbangNameResponse"
+          }
+        }
+      },
+      "RestResponseZzimCheckResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ZzimCheckResponse"
+          }
+        }
+      },
+      "ZzimCheckResponse": {
+        "type": "object",
+        "properties": {
+          "isZzimed": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DarakbangMemberRoleResponse": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseDarakbangMemberRoleResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DarakbangMemberRoleResponse"
+          }
+        }
+      },
+      "PleaseFindAllResponse": {
+        "type": "object",
+        "properties": {
+          "pleaseId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isInterested": {
+            "type": "boolean"
+          },
+          "interestCount": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PleaseFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "pleases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PleaseFindAllResponse"
+            }
+          }
+        }
+      },
+      "RestResponsePleaseFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PleaseFindAllResponses"
+          }
+        }
+      },
+      "NotificationFindAllResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "redirectUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "NotificationFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "notifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationFindAllResponse"
+            }
+          }
+        }
+      },
+      "RestResponseNotificationFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/NotificationFindAllResponses"
+          }
+        }
+      },
+      "MoimFindAllResponse": {
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "place": {
+            "type": "string"
+          },
+          "currentPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "authorNickname": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isZzimed": {
+            "type": "boolean"
+          }
+        }
+      },
+      "MoimFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "moims": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MoimFindAllResponse"
+            }
+          }
+        }
+      },
+      "RestResponseMoimFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/MoimFindAllResponses"
+          }
+        }
+      },
+      "ChildCommentResponse": {
+        "type": "object",
+        "properties": {
+          "commentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CommentResponse": {
+        "type": "object",
+        "properties": {
+          "commentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChildCommentResponse"
+            }
+          }
+        }
+      },
+      "MoimDetailsFindResponse": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "place": {
+            "type": "string"
+          },
+          "currentPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "authorNickname": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommentResponse"
+            }
+          }
+        }
+      },
+      "RestResponseMoimDetailsFindResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/MoimDetailsFindResponse"
+          }
+        }
+      },
+      "DarakbangMemberResponse": {
+        "type": "object",
+        "properties": {
+          "memberId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          }
+        }
+      },
+      "DarakbangMemberResponses": {
+        "type": "object",
+        "properties": {
+          "darakbangMemberResponses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DarakbangMemberResponse"
+            }
+          }
+        }
+      },
+      "RestResponseDarakbangMemberResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DarakbangMemberResponses"
+          }
+        }
+      },
+      "MemberFindResponse": {
+        "type": "object",
+        "properties": {
+          "nickname": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseMemberFindResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/MemberFindResponse"
+          }
+        }
+      },
+      "InvitationCodeResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseInvitationCodeResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/InvitationCodeResponse"
+          }
+        }
+      },
+      "ChatFindDetailResponse": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isMyMessage": {
+            "type": "boolean"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "time": {
+            "$ref": "#/components/schemas/LocalTime"
+          },
+          "chatType": {
+            "type": "string",
+            "enum": [
+              "BASIC",
+              "PLACE",
+              "DATETIME"
+            ]
+          }
+        }
+      },
+      "ChatFindUnloadedResponse": {
+        "type": "object",
+        "properties": {
+          "chats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatFindDetailResponse"
+            }
+          }
+        }
+      },
+      "RestResponseChatFindUnloadedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChatFindUnloadedResponse"
+          }
+        }
+      },
+      "ChatPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "currentPeople": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isStarted": {
+            "type": "boolean"
+          },
+          "lastContent": {
+            "type": "string"
+          },
+          "lastReadChatId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ChatPreviewResponses": {
+        "type": "object",
+        "properties": {
+          "chatPreviewResponses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatPreviewResponse"
+            }
+          }
+        }
+      },
+      "RestResponseChatPreviewResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChatPreviewResponses"
+          }
+        }
+      },
+      "MoimRoleFindResponse": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseMoimRoleFindResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/MoimRoleFindResponse"
+          }
+        }
+      },
+      "ChamyoFindAllResponse": {
+        "type": "object",
+        "properties": {
+          "nickname": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          }
+        }
+      },
+      "ChamyoFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "chamyos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChamyoFindAllResponse"
+            }
+          }
+        }
+      },
+      "RestResponseChamyoFindAllResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ChamyoFindAllResponses"
+          }
+        }
+      },
+      "CodeValidationResponse": {
+        "type": "object",
+        "properties": {
+          "darakbangId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "RestResponseCodeValidationResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/CodeValidationResponse"
+          }
+        }
+      },
+      "DarakbangResponse": {
+        "type": "object",
+        "properties": {
+          "darakbangId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "DarakbangResponses": {
+        "type": "object",
+        "properties": {
+          "darakbangResponses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DarakbangResponse"
+            }
+          }
+        }
+      },
+      "RestResponseDarakbangResponses": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DarakbangResponses"
+          }
+        }
+      },
+      "ChamyoCancelRequest": {
+        "required": [
+          "moimId"
+        ],
+        "type": "object",
+        "properties": {
+          "moimId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Authorization": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

**현재 개발 문서화 과정의 문제**

노션과 스웨거를 동시에 사용하고 있는 지금 아래 두 가지 문제가 있다고 생각했습니다. 
- 중복 작성이 필요하다. 
- 스펙 변경 시 스웨거만 변경되어 혼란이 생긴다. 

하지만 스웨거로 일원화 하기에도 해결되지 못하는 불편함이 있었어요. 
- 상세한 스펙 작성의 불편함
- 코드 리뷰를 통해 개발 서버에 머지 되어야 명세를 제공할 수 있다는 불편함. 즉 반영에 시간이 걸림.

두 가지 불편함을 이렇게 개선했어요. 
- 상세한 스펙 작성의 불편함 👉[ JSON 방식으로 스펙](https://swagger.io/specification/)을 작성하여 어노테이션을 일일이 적는 것보다 시간을 절약할 수 있다.
- 반영에 시간이 걸림 👉 JSON 파일만 개발 서버에 쇽하고 올리면 자동으로 명세가 만들어져 프론트엔드 개발자들이 빠르게 바뀐 명세를 확인할 수 있다.

JSON에 스펙을 작성하고 Gradle Build를 하면, 자동으로 스웨거 인터페이스와 DTO가 만들어지도록 했어요. 명세가 바뀌더라도 중복으로 문서를 수정할 필요는 없습니다!

## 이슈 ID는 무엇인가요?

- #509 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

일단 우리 프로젝트에 적용하는 것을 우선으로 두고 구현하였어요. 
세세하게 수정할 부분이 있는데, 차차 관리하는 것으로 하고 **일단 논의 차 PR 먼저 올립니다.** 😉

이 PR이 적용되고 난 후 기대하는 API 개발 시나리오는 다음과 같아요. 

**API 개발 시나리오**

- `contract.json`에 `json`형식으로 API 명세를 작성한다.
- 변경된 `contract.json` 파일을 API 명세 전용 브랜치 (리뷰 필요 없음) 에 올린다.
- 개발 서버에 API 명세 전용 도커 컨테이너에 변경된 API 스펙이 적용된다.
- 이후에 프로덕션 개발을 시작한다.
    - `./gradlew build`를 입력해 자동으로 스웨거 인터페이스와 DTO를 생성한다.
    - 생성된 인터페이스와 DTO를 활용하여 프로덕션 개발을 진행한다

**개발 서버에 API 명세가 적용되는 시나리오**

- 수정된 JSON 파일이 개발 서버에 업로드 된다.
- 해당 JSON을 볼륨에 마운트하고 있는 도커 컨테이너를 재가동한다.
- `dev.mouda.site`의 특정 포트에 접근하면 변경된 스웨거 UI가 호출된다.

도커 컨테이너 테스트는 로컬에서 이미 진행되어서, 승인 되면 등교 후 빠르게 작업해놓겠습니다 👱‍♀️

자세한 내용은 내일 쯤 팀 블로그에 기재해놓을게요. 

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->

Code Generator가 인터페이스와 DTO를 자동으로 생성하는 부분에서 아쉬운 점이 있다면, 
- 현재는 인터페이스와 DTO 클래스 위치가 도메인 별로 분리되어있는데, 이 방식을 사용하면 하나의 패키지에 몰아넣게 될 것 같아요. 
- `@LoginMember`는 명세에 포함되지 않지만 컨트롤러 파라미터에는 포함돼요. 미스매치가 생겨서 지금 당장 인터페이스를 활용할 수 없을거에요. 

그래서 당장 적용하긴 어려울 것 같고, 이 방식에 대한 피드백을 받고자 PR 올려요. 참고해주세요!