### PR TITLE
알림 기능 추상화로 리팩토링

### DIFF
--- a/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
+++ b/backend/src/main/java/mouda/backend/chamyo/service/ChamyoService.java
@@ -115,8 +115,7 @@ public class ChamyoService {
 			return;
 		}
 
-		Long moimerId = chamyoRepository.findMoimerIdByMoimId(moim.getId());
-		notificationService.notifyToMember(NotificationType.MOIMEE_LEFT, darakbangId, moim, darakbangMember, moimerId);
+		notificationService.notifyToMembers(NotificationType.MOIMEE_LEFT, darakbangId, moim, darakbangMember);
 	}
 
 	private void validateCanCancelChamyo(Moim moim, DarakbangMember darakbangMember) {

--- a/backend/src/main/java/mouda/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/service/ChatService.java
@@ -1,10 +1,8 @@
 package mouda.backend.chat.service;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +26,6 @@ import mouda.backend.chat.repository.ChatRepository;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.repository.MoimRepository;
-import mouda.backend.notification.domain.MoudaNotification;
 import mouda.backend.notification.domain.NotificationType;
 import mouda.backend.notification.service.NotificationService;
 
@@ -36,15 +33,6 @@ import mouda.backend.notification.service.NotificationService;
 @Service
 @RequiredArgsConstructor
 public class ChatService {
-
-	@Value("${url.base}")
-	private String baseUrl;
-
-	@Value("${url.moim}")
-	private String moimUrl;
-
-	@Value("${url.chatroom}")
-	private String chatroomUrl;
 
 	private final ChatRepository chatRepository;
 	private final MoimRepository moimRepository;
@@ -61,19 +49,7 @@ public class ChatService {
 		Chat chat = chatCreateRequest.toEntity(moim, darakbangMember);
 		chatRepository.save(chat);
 
-		NotificationType notificationType = NotificationType.NEW_CHAT;
-		MoudaNotification notification = MoudaNotification.builder()
-			.type(notificationType)
-			.body(notificationType.createMessage(darakbangMember.getNickname()))
-			.targetUrl(baseUrl + String.format(chatroomUrl, darakbangId, moim.getId()))
-			.build();
-
-		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
-			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
-			.filter(memberId -> !Objects.equals(memberId, darakbangMember.getMemberId()))
-			.toList();
-
-		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
+		notificationService.notifyToMembers(NotificationType.NEW_CHAT, darakbangId, moim, darakbangMember);
 	}
 
 	@Transactional(readOnly = true)
@@ -107,24 +83,8 @@ public class ChatService {
 		moim.confirmPlace(placeConfirmRequest.place());
 		chatRepository.save(chat);
 
-		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_PLACE_CONFIRMED, darakbangId);
-	}
+		notificationService.notifyToMembers(NotificationType.MOIM_PLACE_CONFIRMED, darakbangId, moim, darakbangMember);
 
-	private void sendNotificationWhenMoimPlaceOrTimeConfirmed(
-		Moim moim, NotificationType notificationType, Long darakbangId
-	) {
-		MoudaNotification notification = MoudaNotification.builder()
-			.type(notificationType)
-			.body(notificationType.createMessage(moim.getTitle()))
-			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
-			.build();
-
-		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
-			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
-			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
-			.toList();
-
-		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
 	}
 
 	public void confirmDateTime(
@@ -140,7 +100,7 @@ public class ChatService {
 		moim.confirmDateTime(dateTimeConfirmRequest.date(), dateTimeConfirmRequest.time());
 		chatRepository.save(chat);
 
-		sendNotificationWhenMoimPlaceOrTimeConfirmed(moim, NotificationType.MOIM_TIME_CONFIRMED, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOIM_TIME_CONFIRMED, darakbangId, moim, darakbangMember);
 	}
 
 	public ChatPreviewResponses findChatPreview(Long darakbangId, DarakbangMember darakbangMember) {

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -154,8 +154,7 @@ public class MoimService {
 				parentCommentAuthorId);
 		}
 
-		Long moimerId = chamyoRepository.findMoimerIdByMoimId(moim.getId());
-		notificationService.notifyToMember(NotificationType.NEW_COMMENT, darakbangId, moim, author, moimerId);
+		notificationService.notifyToMembers(NotificationType.NEW_COMMENT, darakbangId, moim, author);
 	}
 
 	public void completeMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {

--- a/backend/src/main/java/mouda/backend/moim/service/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/service/MoimService.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ import mouda.backend.comment.exception.CommentErrorMessage;
 import mouda.backend.comment.exception.CommentException;
 import mouda.backend.comment.repository.CommentRepository;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
 import mouda.backend.moim.domain.FilterType;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.domain.MoimStatus;
@@ -35,7 +33,6 @@ import mouda.backend.moim.dto.response.MoimFindAllResponses;
 import mouda.backend.moim.exception.MoimErrorMessage;
 import mouda.backend.moim.exception.MoimException;
 import mouda.backend.moim.repository.MoimRepository;
-import mouda.backend.notification.domain.MoudaNotification;
 import mouda.backend.notification.domain.NotificationType;
 import mouda.backend.notification.service.NotificationService;
 import mouda.backend.zzim.domain.Zzim;
@@ -45,13 +42,6 @@ import mouda.backend.zzim.repository.ZzimRepository;
 @Service
 @RequiredArgsConstructor
 public class MoimService {
-
-	private final DarakbangMemberRepository darakbangMemberRepository;
-	@Value("${url.base}")
-	private String baseUrl;
-
-	@Value("${url.moim}")
-	private String moimUrl;
 
 	private final MoimRepository moimRepository;
 	private final ChamyoRepository chamyoRepository;
@@ -68,18 +58,7 @@ public class MoimService {
 			.build();
 		chamyoRepository.save(chamyo);
 
-		NotificationType notificationType = NotificationType.MOIM_CREATED;
-		MoudaNotification notification = MoudaNotification.builder()
-			.type(notificationType)
-			.body(notificationType.createMessage(moim.getTitle()))
-			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
-			.build();
-
-		List<Long> darakbangMembersExceptMe = darakbangMemberRepository.findAllByDarakbangId(darakbangId).stream()
-			.filter(member -> !Objects.equals(member.getId(), darakbangMember.getId()))
-			.map(DarakbangMember::getMemberId)
-			.toList();
-		notificationService.notifyToMembers(notification, darakbangMembersExceptMe, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOIM_CREATED, darakbangId, moim, darakbangMember);
 		return moim;
 	}
 
@@ -165,26 +144,18 @@ public class MoimService {
 		if (Objects.equals(chamyoRepository.findMoimerIdByMoimId(moimId), darakbangMember.getMemberId())) {
 			return;
 		}
-		sendCommentNotification(moim.getId(), darakbangMember, parentId, darakbangId);
+		sendCommentNotification(moim, darakbangMember, parentId, darakbangId);
 	}
 
-	private void sendCommentNotification(Long moimId, DarakbangMember author, Long parentId, Long darakbangId) {
+	private void sendCommentNotification(Moim moim, DarakbangMember author, Long parentId, Long darakbangId) {
 		if (parentId != null) {
 			Long parentCommentAuthorId = commentRepository.findMemberIdByParentId(parentId);
-			MoudaNotification notification = MoudaNotification.builder()
-				.type(NotificationType.NEW_REPLY)
-				.body(NotificationType.NEW_REPLY.createMessage(author.getNickname()))
-				.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moimId))
-				.build();
-			notificationService.notifyToMember(notification, parentCommentAuthorId, darakbangId);
+			notificationService.notifyToMember(NotificationType.NEW_REPLY, darakbangId, moim, author,
+				parentCommentAuthorId);
 		}
 
-		MoudaNotification notification = MoudaNotification.builder()
-			.type(NotificationType.NEW_COMMENT)
-			.body(NotificationType.NEW_COMMENT.createMessage(author.getNickname()))
-			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moimId))
-			.build();
-		notificationService.notifyToMember(notification, chamyoRepository.findMoimerIdByMoimId(moimId), darakbangId);
+		Long moimerId = chamyoRepository.findMoimerIdByMoimId(moim.getId());
+		notificationService.notifyToMember(NotificationType.NEW_COMMENT, darakbangId, moim, author, moimerId);
 	}
 
 	public void completeMoim(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {
@@ -197,22 +168,7 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.COMPLETED);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIMING_COMPLETED, darakbangId);
-	}
-
-	private void sendNotificationWhenMoimStatusChanged(Moim moim, NotificationType notificationType, Long darakbangId) {
-		MoudaNotification notification = MoudaNotification.builder()
-			.type(notificationType)
-			.body(notificationType.createMessage(moim.getTitle()))
-			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
-			.build();
-
-		List<Long> membersToSendNotification = chamyoRepository.findAllByMoimId(moim.getId()).stream()
-			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
-			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
-			.toList();
-
-		notificationService.notifyToMembers(notification, membersToSendNotification, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOIMING_COMPLETED, darakbangId, moim, darakbangMember);
 	}
 
 	private void validateCanCompleteMoim(Moim moim, DarakbangMember darakbangMember) {
@@ -236,7 +192,7 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.CANCELED);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_CANCELLED, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOIM_CANCELLED, darakbangId, moim, darakbangMember);
 	}
 
 	private void validateCanCancelMoim(Moim moim, DarakbangMember darakbangMember) {
@@ -256,7 +212,7 @@ public class MoimService {
 
 		moimRepository.updateMoimStatusById(moimId, MoimStatus.MOIMING);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOINING_REOPENED, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOINING_REOPENED, darakbangId, moim, darakbangMember);
 	}
 
 	private void validateCanReopenMoim(Moim moim, DarakbangMember darakbangMember) {
@@ -296,7 +252,7 @@ public class MoimService {
 			request.description(), chamyoRepository.countByMoim(moim));
 		moimRepository.save(moim);
 
-		sendNotificationWhenMoimStatusChanged(moim, NotificationType.MOIM_MODIFIED, darakbangId);
+		notificationService.notifyToMembers(NotificationType.MOIM_MODIFIED, darakbangId, moim, darakbangMember);
 	}
 
 	private void validateCanEditMoim(Moim moim, DarakbangMember darakbangMember) {

--- a/backend/src/main/java/mouda/backend/notification/domain/Notifiable.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/Notifiable.java
@@ -1,0 +1,8 @@
+package mouda.backend.notification.domain;
+
+public interface Notifiable {
+
+	String getMessageData();
+
+	long getId();
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/NotificationTypeProvider.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/NotificationTypeProvider.java
@@ -1,0 +1,12 @@
+package mouda.backend.notification.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface NotificationTypeProvider {
+	NotificationType value();
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimCancelledNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimCancelledNotificationBuilder.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_CANCELLED)
+public class MoimCancelledNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimCancelledNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIM_CANCELLED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimCreatedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimCreatedNotificationBuilder.java
@@ -1,0 +1,30 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_CREATED)
+public class MoimCreatedNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimCreatedNotificationBuilder(MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIM_CREATED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimModifiedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimModifiedNotificationBuilder.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_MODIFIED)
+public class MoimModifiedNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimModifiedNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIM_MODIFIED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimNotificationBuilder.java
@@ -1,0 +1,18 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@RequiredArgsConstructor
+public abstract class MoimNotificationBuilder implements NotificationBuilderStrategy {
+
+	@Value("${url.base}")
+	protected String baseUrl;
+
+	@Value("${url.moim}")
+	protected String moimUrl;
+
+	protected final MoudaNotificationRepository moudaNotificationRepository;
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimPlaceConfirmedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimPlaceConfirmedNotificationBuilder.java
@@ -1,0 +1,31 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_PLACE_CONFIRMED)
+public class MoimPlaceConfirmedNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimPlaceConfirmedNotificationBuilder(MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIM_PLACE_CONFIRMED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimTimeConfirmedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimTimeConfirmedNotificationBuilder.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_TIME_CONFIRMED)
+public class MoimTimeConfirmedNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimTimeConfirmedNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIM_TIME_CONFIRMED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimeeLeftNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimeeLeftNotificationBuilder.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIMEE_LEFT)
+public class MoimeeLeftNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimeeLeftNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIMEE_LEFT;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(sender.getNickname()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimingCompletedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimingCompletedNotificationBuilder.java
@@ -1,0 +1,31 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIMING_COMPLETED)
+public class MoimingCompletedNotificationBuilder extends MoimNotificationBuilder {
+	public MoimingCompletedNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOIMING_COMPLETED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/MoimingReopenedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/MoimingReopenedNotificationBuilder.java
@@ -1,0 +1,31 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOINING_REOPENED)
+public class MoimingReopenedNotificationBuilder extends MoimNotificationBuilder {
+
+	public MoimingReopenedNotificationBuilder(MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.MOINING_REOPENED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(moim.getTitle()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/NewChatNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/NewChatNotificationBuilder.java
@@ -1,0 +1,38 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_CHAT)
+@RequiredArgsConstructor
+public class NewChatNotificationBuilder implements NotificationBuilderStrategy {
+
+	@Value("${url.base}")
+	private String baseUrl;
+
+	@Value("${url.chatroom}")
+	private String chatroomUrl;
+
+	private final MoudaNotificationRepository moudaNotificationRepository;
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.NEW_CHAT;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(sender.getNickname()))
+			.targetUrl(baseUrl + String.format(chatroomUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/NewCommentNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/NewCommentNotificationBuilder.java
@@ -1,0 +1,31 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_COMMENT)
+public class NewCommentNotificationBuilder extends MoimNotificationBuilder {
+
+	public NewCommentNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember author) {
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(NotificationType.NEW_COMMENT)
+			.body(NotificationType.NEW_COMMENT.createMessage(author.getNickname()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/NewMoimeeJoinedNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/NewMoimeeJoinedNotificationBuilder.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_MOIMEE_JOINED)
+public class NewMoimeeJoinedNotificationBuilder extends MoimNotificationBuilder {
+
+	public NewMoimeeJoinedNotificationBuilder(
+		MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
+		NotificationType notificationType = NotificationType.NEW_MOIMEE_JOINED;
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(notificationType)
+			.body(notificationType.createMessage(sender.getNickname()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/NewReplyNotificationBuilder.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/NewReplyNotificationBuilder.java
@@ -1,0 +1,30 @@
+package mouda.backend.notification.domain.notification;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MoudaNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_REPLY)
+public class NewReplyNotificationBuilder extends MoimNotificationBuilder {
+
+	public NewReplyNotificationBuilder(MoudaNotificationRepository moudaNotificationRepository) {
+		super(moudaNotificationRepository);
+	}
+
+	@Override
+	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember author) {
+		MoudaNotification notification = MoudaNotification.builder()
+			.type(NotificationType.NEW_REPLY)
+			.body(NotificationType.NEW_REPLY.createMessage(author.getNickname()))
+			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
+			.build();
+
+		return moudaNotificationRepository.save(notification);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/notification/NotificationBuilderStrategy.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/notification/NotificationBuilderStrategy.java
@@ -1,0 +1,9 @@
+package mouda.backend.notification.domain.notification;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+
+public interface NotificationBuilderStrategy {
+	MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender);
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCanclledNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCanclledNotificationRecipientResolver.java
@@ -1,0 +1,21 @@
+package mouda.backend.notification.domain.recipient;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_CANCELLED)
+public class MoimCanclledNotificationRecipientResolver extends MoimStatusChangedNotificationRecipientResolver {
+
+	public MoimCanclledNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCompletedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCompletedNotificationRecipientResolver.java
@@ -1,0 +1,22 @@
+package mouda.backend.notification.domain.recipient;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIMING_COMPLETED)
+public class MoimCompletedNotificationRecipientResolver extends MoimStatusChangedNotificationRecipientResolver {
+
+	public MoimCompletedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository
+	) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCreatedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimCreatedNotificationRecipientResolver.java
@@ -1,0 +1,38 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_CREATED)
+public class MoimCreatedNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+
+	public MoimCreatedNotificationRecipientResolver(DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		List<Long> recipientsIds = darakbangMemberRepository.findAllByDarakbangId(darakbangId).stream()
+			.filter(member -> !Objects.equals(member.getId(), sender.getId()))
+			.map(DarakbangMember::getMemberId)
+			.toList();
+
+		saveNotificationsForMembers(recipientsIds, darakbangId, notification);
+		return recipientsIds;
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimModifiedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimModifiedNotificationRecipientResolver.java
@@ -1,0 +1,21 @@
+package mouda.backend.notification.domain.recipient;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_MODIFIED)
+public class MoimModifiedNotificationRecipientResolver extends MoimStatusChangedNotificationRecipientResolver {
+
+	public MoimModifiedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimPlaceConfirmedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimPlaceConfirmedNotificationRecipientResolver.java
@@ -1,0 +1,38 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.domain.MoimRole;
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_PLACE_CONFIRMED)
+public class MoimPlaceConfirmedNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+	public MoimPlaceConfirmedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		List<Long> recipientIds = chamyoRepository.findAllByMoimId(moim.getId()).stream()
+			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
+			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
+			.toList();
+
+		saveNotificationsForMembers(recipientIds, darakbangId, notification);
+		return recipientIds;
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimStatusChangedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimStatusChangedNotificationRecipientResolver.java
@@ -1,0 +1,34 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import mouda.backend.chamyo.domain.MoimRole;
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+public abstract class MoimStatusChangedNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+
+	public MoimStatusChangedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository
+	) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		List<Long> recipientIds = chamyoRepository.findAllByMoimId(moim.getId()).stream()
+			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
+			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
+			.toList();
+
+		saveNotificationsForMembers(recipientIds, darakbangId, notification);
+		return recipientIds;
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimTimeConfirmedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimTimeConfirmedNotificationRecipientResolver.java
@@ -1,0 +1,39 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.domain.MoimRole;
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIM_TIME_CONFIRMED)
+public class MoimTimeConfirmedNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+
+	public MoimTimeConfirmedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		List<Long> recipientIds = chamyoRepository.findAllByMoimId(moim.getId()).stream()
+			.filter(chamyo -> chamyo.getMoimRole() != MoimRole.MOIMER)
+			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
+			.toList();
+
+		saveNotificationsForMembers(recipientIds, darakbangId, notification);
+		return recipientIds;
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimeeLeftNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimeeLeftNotificationRecipientResolver.java
@@ -1,0 +1,32 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOIMEE_LEFT)
+public class MoimeeLeftNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+
+	public MoimeeLeftNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		return List.of(chamyoRepository.findMoimerIdByMoimId(moim.getId()));
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimingReopenedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/MoimingReopenedNotificationRecipientResolver.java
@@ -1,0 +1,21 @@
+package mouda.backend.notification.domain.recipient;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.MOINING_REOPENED)
+public class MoimingReopenedNotificationRecipientResolver extends MoimStatusChangedNotificationRecipientResolver {
+	
+	public MoimingReopenedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/NewChatNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/NewChatNotificationRecipientResolver.java
@@ -1,0 +1,34 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_CHAT)
+public class NewChatNotificationRecipientResolver implements RecipientResolverStrategy {
+
+	private final ChamyoRepository chamyoRepository;
+
+	public NewChatNotificationRecipientResolver(ChamyoRepository chamyoRepository) {
+		this.chamyoRepository = chamyoRepository;
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+
+		return chamyoRepository.findAllByMoimId(moim.getId()).stream()
+			.map(chamyo -> chamyo.getDarakbangMember().getMemberId())
+			.filter(memberId -> !Objects.equals(memberId, sender.getMemberId()))
+			.toList();
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/NewCommentNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/NewCommentNotificationRecipientResolver.java
@@ -1,0 +1,31 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_COMMENT)
+public class NewCommentNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+	public NewCommentNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+		return List.of(chamyoRepository.findMoimerIdByMoimId(moim.getId()));
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/NewMoimeeJoinedNotificationRecipientResolver.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/NewMoimeeJoinedNotificationRecipientResolver.java
@@ -1,0 +1,40 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@Component
+@NotificationTypeProvider(NotificationType.NEW_MOIMEE_JOINED)
+public class NewMoimeeJoinedNotificationRecipientResolver extends NoneChatRecipientResolverStrategy {
+
+	public NewMoimeeJoinedNotificationRecipientResolver(
+		DarakbangMemberRepository darakbangMemberRepository,
+		MemberNotificationRepository memberNotificationRepository,
+		ChamyoRepository chamyoRepository
+	) {
+		super(darakbangMemberRepository, memberNotificationRepository, chamyoRepository);
+	}
+
+	@Override
+	public List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender) {
+
+		List<Long> recipientIds = chamyoRepository.findAllByMoimId(moim.getId()).stream()
+			.map(c -> c.getDarakbangMember().getMemberId())
+			.filter(memberId -> !memberId.equals(sender.getMemberId()))
+			.toList();
+
+		saveNotificationsForMembers(recipientIds, darakbangId, notification);
+		return recipientIds;
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/NoneChatRecipientResolverStrategy.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/NoneChatRecipientResolverStrategy.java
@@ -1,0 +1,29 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.chamyo.repository.ChamyoRepository;
+import mouda.backend.darakbangmember.repository.repository.DarakbangMemberRepository;
+import mouda.backend.notification.domain.MemberNotification;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.repository.MemberNotificationRepository;
+
+@RequiredArgsConstructor
+public abstract class NoneChatRecipientResolverStrategy implements RecipientResolverStrategy {
+	
+	protected final DarakbangMemberRepository darakbangMemberRepository;
+	protected final MemberNotificationRepository memberNotificationRepository;
+	protected final ChamyoRepository chamyoRepository;
+
+	public void saveNotificationsForMembers(List<Long> recipientsIds, long darakbangId,
+		MoudaNotification notification) {
+		memberNotificationRepository.saveAll(recipientsIds.stream()
+			.map(memberId -> MemberNotification.builder()
+				.memberId(memberId)
+				.darakbangId(darakbangId)
+				.moudaNotification(notification)
+				.build())
+			.toList());
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/domain/recipient/RecipientResolverStrategy.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/recipient/RecipientResolverStrategy.java
@@ -1,0 +1,13 @@
+package mouda.backend.notification.domain.recipient;
+
+import java.util.List;
+
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.notification.domain.MoudaNotification;
+
+public interface RecipientResolverStrategy {
+
+	List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
+		DarakbangMember sender);
+}

--- a/backend/src/main/java/mouda/backend/notification/service/FcmService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/FcmService.java
@@ -1,0 +1,113 @@
+package mouda.backend.notification.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.SendResponse;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushFcmOptions;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mouda.backend.notification.domain.FcmToken;
+import mouda.backend.notification.domain.MoudaNotification;
+import mouda.backend.notification.repository.FcmTokenRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+	private final FcmTokenRepository fcmTokenRepository;
+
+	public void sendNotification(MoudaNotification notification, List<String> tokens) {
+		if (tokens.isEmpty()) {
+			return;
+		}
+
+		List<List<String>> chunkedTokens = chunkFcmTokensForMulticast(tokens);
+
+		chunkedTokens.stream()
+			.map(chunk -> MulticastMessage.builder()
+				.setNotification(notification.toFcmNotification())
+				.setWebpushConfig(getWebpushConfig(notification.getTargetUrl()))
+				.addAllTokens(chunk)
+				.build())
+			.forEach(message -> {
+				try {
+					BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+					validateFcmTokenByErrorCode(tokens, batchResponse);
+				} catch (FirebaseMessagingException e) {
+					log.error("Failed to send message: {}", e.getMessage());
+				}
+			});
+	}
+
+	private List<List<String>> chunkFcmTokensForMulticast(List<String> tokens) {
+		int defaultChunkSize = 500;
+		List<List<String>> result = new ArrayList<>();
+		for (int i = 0; i < tokens.size(); i += defaultChunkSize) {
+			result.add(tokens.subList(i, Math.min(i + defaultChunkSize, tokens.size())));
+		}
+		return result;
+	}
+
+	private WebpushConfig getWebpushConfig(String url) {
+		return WebpushConfig.builder()
+			.setFcmOptions(WebpushFcmOptions.withLink(url))
+			.build();
+	}
+
+	private void validateFcmTokenByErrorCode(List<String> tokens, BatchResponse batchResponse) {
+		if (batchResponse.getFailureCount() == 0) {
+			return;
+		}
+
+		List<SendResponse> responses = batchResponse.getResponses();
+		IntStream.range(0, responses.size())
+			.filter(index -> isInvalidTokenErrorCode(responses.get(index)))
+			.forEach(index -> fcmTokenRepository.deleteByToken(tokens.get(index)));
+	}
+
+	private boolean isInvalidTokenErrorCode(SendResponse sendResponse) {
+		if (sendResponse.isSuccessful()) {
+			return false;
+		}
+		MessagingErrorCode errorCode = sendResponse.getException().getMessagingErrorCode();
+		return errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
+	}
+
+	public void registerToken(long memberId, String token) {
+		fcmTokenRepository.findByToken(token)
+			.ifPresentOrElse(
+				FcmToken::refreshTimestamp,
+				() -> {
+					FcmToken fcmToken = FcmToken.builder()
+						.memberId(memberId)
+						.fcmToken(token)
+						.build();
+					fcmTokenRepository.save(fcmToken);
+				}
+			);
+	}
+
+	@Scheduled(cron = "0 0 0 1 * *")
+	public void cleanInactiveTokens() {
+		fcmTokenRepository.findAll()
+			.forEach(token -> {
+				if (token.getTimestamp().isBefore(LocalDateTime.now().minusMonths(1L))) {
+					fcmTokenRepository.delete(token);
+				}
+			});
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationFactory.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationFactory.java
@@ -1,0 +1,30 @@
+package mouda.backend.notification.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.domain.notification.NotificationBuilderStrategy;
+
+@Service
+public class NotificationFactory {
+
+	private final Map<NotificationType, NotificationBuilderStrategy> strategies;
+
+	public NotificationFactory(List<NotificationBuilderStrategy> strategyList) {
+		this.strategies = strategyList.stream()
+			.collect(
+				Collectors.toMap(strategy -> {
+						return strategy.getClass().getAnnotation(NotificationTypeProvider.class).value();
+					},
+					strategy -> strategy));
+	}
+
+	public NotificationBuilderStrategy getStrategy(NotificationType type) {
+		return strategies.get(type);
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/mouda/backend/notification/service/NotificationService.java
@@ -1,29 +1,16 @@
 package mouda.backend.notification.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.IntStream;
 
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.firebase.FirebaseException;
-import com.google.firebase.messaging.BatchResponse;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.MessagingErrorCode;
-import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.SendResponse;
-import com.google.firebase.messaging.WebpushConfig;
-import com.google.firebase.messaging.WebpushFcmOptions;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mouda.backend.member.domain.Member;
-import mouda.backend.notification.domain.FcmToken;
 import mouda.backend.notification.domain.MemberNotification;
 import mouda.backend.notification.domain.MoudaNotification;
 import mouda.backend.notification.domain.NotificationType;
@@ -43,29 +30,10 @@ public class NotificationService {
 	private final FcmTokenRepository fcmTokenRepository;
 	private final MoudaNotificationRepository moudaNotificationRepository;
 	private final MemberNotificationRepository memberNotificationRepository;
+	private final FcmService fcmService;
 
 	public void registerFcmToken(long memberId, FcmTokenSaveRequest fcmTokenSaveRequest) {
-		fcmTokenRepository.findByToken(fcmTokenSaveRequest.token())
-			.ifPresentOrElse(
-				FcmToken::refreshTimestamp,
-				() -> {
-					FcmToken fcmToken = FcmToken.builder()
-						.memberId(memberId)
-						.fcmToken(fcmTokenSaveRequest.token())
-						.build();
-					fcmTokenRepository.save(fcmToken);
-				}
-			);
-	}
-
-	@Scheduled(cron = "0 0 0 1 * *")
-	public void cleanInactiveFcmTokens() {
-		fcmTokenRepository.findAll()
-			.forEach(token -> {
-				if (token.getTimestamp().isBefore(LocalDateTime.now().minusMonths(1L))) {
-					fcmTokenRepository.delete(token);
-				}
-			});
+		fcmService.registerToken(memberId, fcmTokenSaveRequest.token());
 	}
 
 	public void notifyToMember(MoudaNotification moudaNotification, Long memberId, Long darakbangId) {
@@ -80,7 +48,7 @@ public class NotificationService {
 		}
 
 		List<String> tokens = fcmTokenRepository.findAllTokenByMemberId(memberId);
-		sendNotificationToAll(notification, tokens);
+		fcmService.sendNotification(notification, tokens);
 	}
 
 	public void notifyToAllMembers(MoudaNotification moudaNotification, Long darakbangId) {
@@ -120,39 +88,7 @@ public class NotificationService {
 		}
 
 		List<String> tokens = fcmTokenRepository.findAllTokenByMemberIds(memberIds);
-		sendNotificationToAll(notification, tokens);
-	}
-
-	private void sendNotificationToAll(MoudaNotification notification, List<String> tokens) {
-		if (tokens.isEmpty()) {
-			return;
-		}
-
-		List<List<String>> chunkedTokens = chunkFcmTokensForMulticast(tokens);
-
-		chunkedTokens.stream()
-			.map(chunk -> MulticastMessage.builder()
-				.setNotification(notification.toFcmNotification())
-				.setWebpushConfig(getWebpushConfig(notification.getTargetUrl()))
-				.addAllTokens(chunk)
-				.build())
-			.forEach(message -> {
-				try {
-					BatchResponse batchResponse = FirebaseMessaging.getInstance().sendEachForMulticast(message);
-					validateFcmTokenByErrorCode(tokens, batchResponse);
-				} catch (FirebaseMessagingException e) {
-					log.error("Failed to send message: {}", e.getMessage());
-				}
-			});
-	}
-
-	private List<List<String>> chunkFcmTokensForMulticast(List<String> tokens) {
-		int defaultChunkSize = 500;
-		List<List<String>> result = new ArrayList<>();
-		for (int i = 0; i < tokens.size(); i += defaultChunkSize) {
-			result.add(tokens.subList(i, Math.min(i + defaultChunkSize, tokens.size())));
-		}
-		return result;
+		fcmService.sendNotification(notification, tokens);
 	}
 
 	public NotificationFindAllResponses findAllMyNotifications(Member member, Long darakbangId) {
@@ -164,30 +100,5 @@ public class NotificationService {
 			.toList();
 
 		return new NotificationFindAllResponses(responses);
-	}
-
-	private WebpushConfig getWebpushConfig(String url) {
-		return WebpushConfig.builder()
-			.setFcmOptions(WebpushFcmOptions.withLink(url))
-			.build();
-	}
-
-	private void validateFcmTokenByErrorCode(List<String> tokens, BatchResponse batchResponse) {
-		if (batchResponse.getFailureCount() == 0) {
-			return;
-		}
-
-		List<SendResponse> responses = batchResponse.getResponses();
-		IntStream.range(0, responses.size())
-			.filter(index -> isInvalidTokenErrorCode(responses.get(index)))
-			.forEach(index -> fcmTokenRepository.deleteByToken(tokens.get(index)));
-	}
-
-	private boolean isInvalidTokenErrorCode(SendResponse sendResponse) {
-		if (sendResponse.isSuccessful()) {
-			return false;
-		}
-		MessagingErrorCode errorCode = sendResponse.getException().getMessagingErrorCode();
-		return errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/service/RecipientFactory.java
+++ b/backend/src/main/java/mouda/backend/notification/service/RecipientFactory.java
@@ -1,0 +1,29 @@
+package mouda.backend.notification.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import mouda.backend.notification.domain.NotificationType;
+import mouda.backend.notification.domain.NotificationTypeProvider;
+import mouda.backend.notification.domain.recipient.RecipientResolverStrategy;
+
+@Service
+public class RecipientFactory {
+	private final Map<NotificationType, RecipientResolverStrategy> strategies;
+
+	public RecipientFactory(List<RecipientResolverStrategy> strategyList) {
+		this.strategies = strategyList.stream()
+			.collect(
+				Collectors.toMap(strategy -> {
+						return strategy.getClass().getAnnotation(NotificationTypeProvider.class).value();
+					},
+					strategy -> strategy));
+	}
+
+	public RecipientResolverStrategy getStrategy(NotificationType type) {
+		return strategies.get(type);
+	}
+}

--- a/backend/src/test/java/mouda/backend/IgnoreNotificationTest.java
+++ b/backend/src/test/java/mouda/backend/IgnoreNotificationTest.java
@@ -17,10 +17,10 @@ public class IgnoreNotificationTest {
 
 	@BeforeEach
 	void setUp() {
-		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyLong(), anyLong());
-		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyList(), anyLong());
-		doNothing().when(notificationService).notifyToAllMembers(any(), anyLong());
-		doNothing().when(notificationService).notifyToMember(any(), any(), anyLong());
-		doNothing().when(notificationService).notifyToMembers(any(), any(), anyLong());
+		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyLong(), any(), any(), anyLong());
+		doNothing().when(notificationService).notifyToAllExceptMember(any(), anyLong(), any(), any(), anyList());
+		doNothing().when(notificationService).notifyToAllMembers(any(), anyLong(), any(), any());
+		doNothing().when(notificationService).notifyToMember(any(), anyLong(), any(), any(), anyLong());
+		doNothing().when(notificationService).notifyToMembers(any(), anyLong(), any(), any());
 	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
여러 Service 객체의 알림 관련 의존성으로 인한 유지보수 및  관리 어려움 해결 

## 이슈 ID는 무엇인가요?

- #508 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->
코드 변경이 많아서 글로만 이해가 안될 수 있어요! 필요하다면 꼭 제게 물어봐주세요!!!!!!!

1. 알림을 보낼 수 있는 서비스(MoimService, ChatService, ChamyoService)가 Notification 관련 기능과 너무 많은 연관관계를 맺고 있음. → 유지보수 어려움
2. 사실상 같은 기능임에도 10 줄 정도의 반복적인 코드들이 산재해 있음 
3. 의존성으로 인한 도메인 로직의 손상위험 있음.
4. FCM 관련 의존성이 NotificationService와 높은 의존성을 가짐으로 인해 테스트 코드 작성에 어려움

위 같은 현상이 반복되는 이유는 모우다의 알림 기능에 다음과 같은 요구사항이 있기 때문. 

#### 요구사항

1. 알림의 종류를 구분할 수 있다. 
    1. 색상에 따른 알림 종류 변경
    2. 같은 모임 알림이라고 하더라도 종류가 다름(모임 생성, 댓글 등)
    3. 채팅은 알림을 보내지 않고 알림 센터에만 보여줌
2. 알림을 보낼 사람을 선별할 수 있다. 
    1. 전체
    2. 자기 제외, 방에 있는 사람들만
    3. 답글이 달린 댓글 작성자만 
    5. 등등

#### 해결방안
##### FCM 관련 의존성을 NotificationService와 분리
```java
public class FcmService {

	private final FcmTokenRepository fcmTokenRepository;

	public void sendNotification(MoudaNotification notification, List<String> tokens) {
		if (tokens.isEmpty()) {
			return;
		}
        ...
```
결과 : __알림 기능 중 `FcmService` 를 테스트 코드에서 대체할 Mock 객체를 만들어서 테스트 가능__

##### 전략 패턴으로 알림 종류에 따른 알림 빌더, 송신자 결정 로직 분리 
위 요구사항들은 같은 기능이라도 ‘전략’에 따른 다른 동작을 하기를 원함
 → 전략 패턴을 통한 개선

```java
// 알림 빌더 전략 인터페이스
public interface NotificationBuilderStrategy {

	MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender);
}

```

```java
// 알림 송신 대상 전략 인터페이스
public interface RecipientResolverStrategy {

	List<Long> resolveRecipients(long darakbangId, MoudaNotification notification, Moim moim,
		DarakbangMember sender);
}
```

**결과** 
```java
public void notifyToMembers(NotificationType type, Long darakbangId, Moim moim, DarakbangMember sender) {
    MoudaNotification notification = notificationFactory.getStrategy(type)
	    .buildNotification(darakbangId, moim, sender);
    List<Long> recipients = recipientFactory.getStrategy(type)
	    .resolveRecipients(darakbangId, notification, moim, sender);
    
    List<String> tokens = fcmTokenRepository.findAllTokenByMemberIds(recipients);
    fcmService.sendNotification(notification, tokens);
    }
```
NotificationType 에 다라 다른 알림 생성,송신자 계산 결정 로직이 결정되도록 수정됨. 

```java
@Component
@NotificationTypeProvider(NotificationType.MOIM_CANCELLED)
public class MoimCancelledNotificationBuilder extends MoimNotificationBuilder {

	public MoimCancelledNotificationBuilder(
		MoudaNotificationRepository moudaNotificationRepository) {
		super(moudaNotificationRepository);
	}

	@Override
	public MoudaNotification buildNotification(Long darakbangId, Moim moim, DarakbangMember sender) {
		NotificationType notificationType = NotificationType.MOIM_CANCELLED;
		MoudaNotification notification = MoudaNotification.builder()
			.type(notificationType)
			.body(notificationType.createMessage(moim.getTitle()))
			.targetUrl(baseUrl + String.format(moimUrl, darakbangId, moim.getId()))
			.build();

		return moudaNotificationRepository.save(notification);
	}
}
```
**새로운 알림 종류가 생겼을 때에는 전송 전략을 구현하는 객체를 추가하는 것으로 확장성 개선**


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
- 구현체별로 공통 코드들을 abstract class 로 분리해놓은 경우가 있어서 혹시 이해가 안되면 물어봐주세요!
- 추가로 AOP 를 적용시켜놓으려했으나 
  ```java
	private void sendCommentNotification(Moim moim, DarakbangMember author, Long parentId, Long darakbangId) {
		if (parentId != null) {
			Long parentCommentAuthorId = commentRepository.findMemberIdByParentId(parentId);
			notificationService.notifyToMember(NotificationType.NEW_REPLY, darakbangId, moim, author,
				parentCommentAuthorId);
		}

		notificationService.notifyToMembers(NotificationType.NEW_COMMENT, darakbangId, moim, author);
	}

   ```
   위 로직 한 곳에서 parentId 라는 클라이언트에서 보내주는 데이터에 대한 의존이 생겨서 고민중입니다. 함께 이야기 해봐요!