### PR TITLE
아이폰 사용자를 위한 새로고침 버튼 추가 

### DIFF
--- a/frontend/src/common/assets/refresh.svg
+++ b/frontend/src/common/assets/refresh.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21.8883 13.5C21.1645 18.3113 17.013 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C16.1006 2 19.6248 4.46819 21.1679 8" stroke="#131927" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 8H21.4C21.7314 8 22 7.73137 22 7.4V3" stroke="#131927" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/RefreshButton/RefreshButton.style.ts
+++ b/frontend/src/components/RefreshButton/RefreshButton.style.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const noneBaackgroundButton = css`
+  background: none;
+  border: none;
+  cursor: pointer;
+`;

--- a/frontend/src/components/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/components/RefreshButton/RefreshButton.tsx
@@ -1,0 +1,20 @@
+import { useQueryClient } from '@tanstack/react-query';
+import QUERY_KEYS from '@_constants/queryKeys';
+import { getLastDarakbangId } from '@_common/lastDarakbangManager';
+import Refresh from '@_common/assets/refresh.svg';
+import { noneBaackgroundButton } from './RefreshButton.style';
+export default function RefreshButton() {
+  const queryClient = useQueryClient();
+  return (
+    <button
+      css={noneBaackgroundButton}
+      onClick={() =>
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEYS.darakbang, getLastDarakbangId()],
+        })
+      }
+    >
+      <Refresh />
+    </button>
+  );
+}

--- a/frontend/src/layouts/PleaseLayout/PleaseLayout.tsx
+++ b/frontend/src/layouts/PleaseLayout/PleaseLayout.tsx
@@ -1,9 +1,9 @@
 import { PropsWithChildren } from 'react';
-import PleaseHeader from './PleaseHeader/PleaseHeader';
 import PleaseMain from './PleaseMain/PleaseMain';
 import PleaseFixedButtonWrapper from './PleaseFixedButtonWrapper/PleaseFixedButtonWrapper';
 import * as S from './PleaseLayout.style';
 import { useTheme } from '@emotion/react';
+import StickyTriSectionHeader from '@_layouts/components/StickyTriSectionHeader/StickyTriSectionHeader';
 
 function PleaseLayout(props: PropsWithChildren) {
   const { children } = props;
@@ -13,7 +13,7 @@ function PleaseLayout(props: PropsWithChildren) {
   return <div css={S.containerStyle({ theme })}>{children}</div>;
 }
 
-PleaseLayout.Header = PleaseHeader;
+PleaseLayout.Header = StickyTriSectionHeader;
 PleaseLayout.Main = PleaseMain;
 PleaseLayout.HomeFixedButtonWrapper = PleaseFixedButtonWrapper;
 

--- a/frontend/src/pages/ChatPage/ChatPage.stories.tsx
+++ b/frontend/src/pages/ChatPage/ChatPage.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import ChatPage from './ChatPage';
+
+const meta = {
+  title: 'pages/ChatPage',
+  component: ChatPage,
+} satisfies Meta<typeof ChatPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <ChatPage />,
+};

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -31,6 +31,7 @@ import useServeToken from '@_hooks/mutaions/useServeToken';
 import Modal from '@_components/Modal/Modal';
 import { useTheme } from '@emotion/react';
 import Button from '@_components/Button/Button';
+import RefreshButton from '@_components/RefreshButton/RefreshButton';
 
 export default function MainPage() {
   const navigate = useNavigate();
@@ -164,6 +165,7 @@ export default function MainPage() {
               <button css={S.headerButton} onClick={handleNotification}>
                 <Notification />
               </button>
+              <RefreshButton />
             </HomeLayout.Header.Top.Right>
           </HomeLayout.Header.Top>
           {isDarakbangMenuOpened && darakbangMenu}

--- a/frontend/src/pages/MoimDetailPage/MoimDetailPage.stories.tsx
+++ b/frontend/src/pages/MoimDetailPage/MoimDetailPage.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import MoimDetailPage from './MoimDetailPage';
+
+const meta = {
+  title: 'pages/MoimDetailPage',
+  component: MoimDetailPage,
+} satisfies Meta<typeof MoimDetailPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <MoimDetailPage />,
+};

--- a/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
+++ b/frontend/src/pages/MoimDetailPage/MoimDetailPage.tsx
@@ -29,6 +29,7 @@ import useOpenChat from '@_hooks/mutaions/useOpenChat';
 import useReopenMoim from '@_hooks/mutaions/useReopenMoim';
 import { useTheme } from '@emotion/react';
 import useZzimMine from '@_hooks/queries/useZzimMine';
+import RefreshButton from '@_components/RefreshButton/RefreshButton';
 
 export default function MoimDetailPage() {
   const navigate = useNavigate();
@@ -112,7 +113,7 @@ export default function MoimDetailPage() {
 
   const button = useMemo(() => {
     return isChamyoMineLoading ? (
-      <></>
+      ''
     ) : role === 'MOIMER' ? (
       moim?.status === 'MOIMING' ? (
         <Button
@@ -198,6 +199,7 @@ export default function MoimDetailPage() {
             />
           )}
           {kebabMenu}
+          <RefreshButton />
         </InformationLayout.Header.Right>
       </InformationLayout.Header>
       <InformationLayout.ContentContainer>
@@ -208,17 +210,17 @@ export default function MoimDetailPage() {
         {participants && <ProfileList participants={participants} />}
 
         {isMoimLoading && (
-          <>
+          <div>
             <span css={theme.typography.s1}>모임정보</span>
             <SkeletonPiece width="100%" height="10rem" />
-          </>
+          </div>
         )}
         {moim && <MoimInformation moimInfo={moim} />}
         {isMoimLoading && (
-          <>
+          <div>
             <SkeletonPiece width="100%" height="10rem" />
             <SkeletonPiece width="100%" height="10rem" />
-          </>
+          </div>
         )}
         {isMoimLoading && <SkeletonPiece width="100%" height="30rem" />}
         {moim?.description && (

--- a/frontend/src/pages/NotificationPage/NotificationPage.stories.tsx
+++ b/frontend/src/pages/NotificationPage/NotificationPage.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import NotificationPage from './NotificationPage';
+
+const meta = {
+  title: 'pages/NotificationPage',
+  component: NotificationPage,
+} satisfies Meta<typeof NotificationPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <NotificationPage />,
+};

--- a/frontend/src/pages/NotificationPage/NotificationPage.tsx
+++ b/frontend/src/pages/NotificationPage/NotificationPage.tsx
@@ -8,6 +8,7 @@ import Modal from '@_components/Modal/Modal';
 import Button from '@_components/Button/Button';
 import { useTheme } from '@emotion/react';
 import * as S from './NotificationPage.style';
+import RefreshButton from '@_components/RefreshButton/RefreshButton';
 
 export default function NotificationPage() {
   const navigate = useNavigate();
@@ -32,6 +33,9 @@ export default function NotificationPage() {
               <BackLogo />
             </div>
           </InformationLayout.Header.Left>
+          <InformationLayout.Header.Right>
+            <RefreshButton />
+          </InformationLayout.Header.Right>
           <InformationLayout.Header.Center>
             알림
           </InformationLayout.Header.Center>

--- a/frontend/src/pages/PleasePage/PleasePage.stories.tsx
+++ b/frontend/src/pages/PleasePage/PleasePage.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react/*';
+import PleasePage from './PleasePage';
+
+const meta = {
+  title: 'pages/PleasePage',
+  component: PleasePage,
+} satisfies Meta<typeof PleasePage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <PleasePage />,
+};

--- a/frontend/src/pages/PleasePage/PleasePage.tsx
+++ b/frontend/src/pages/PleasePage/PleasePage.tsx
@@ -10,6 +10,7 @@ import { common } from '@_common/common.style';
 import { useNavigate } from 'react-router-dom';
 import useNowDarakbangName from '@_hooks/queries/useNowDarakbangNameById';
 import { useTheme } from '@emotion/react';
+import RefreshButton from '@_components/RefreshButton/RefreshButton';
 
 export default function PleasePage() {
   const { darakbangName } = useNowDarakbangName();
@@ -21,9 +22,14 @@ export default function PleasePage() {
     <Fragment>
       <PleaseLayout>
         <PleaseLayout.Header>
-          <h1 css={[common.nonScroll, theme.typography.h5]}>
-            <DarakbangNameWrapper>{darakbangName}</DarakbangNameWrapper>
-          </h1>
+          <PleaseLayout.Header.Left>
+            <h1 css={[common.nonScroll, theme.typography.h5]}>
+              <DarakbangNameWrapper>{darakbangName}</DarakbangNameWrapper>
+            </h1>
+          </PleaseLayout.Header.Left>
+          <PleaseLayout.Header.Right>
+            <RefreshButton />
+          </PleaseLayout.Header.Right>
         </PleaseLayout.Header>
 
         <PleaseLayout.Main>


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

아이폰 사용자를 위한 새로고침 요구사항이 있어 추가했습니다.

## 이슈 ID는 무엇인가요?

- #514

## 설명
아이폰은 안드로이드와 다르게 새로고침을 위해서 페이지를 이동해야합니다. 
이에 대한 새로고림 요구사항이 있어 새로고침 버튼을 추가했습니다.

다만 새로고침 이외에도 tanstack 쿼리를 통해 만료 시간을 설정해 주기적으로 새로운 정보를 받아오는 방식도 생걱을 해보았으나 일단 새로고침 버튼만 만들어 보았습니다. 여러분의 생각은 어떠신가요?

<img width="547" alt="image" src="https://github.com/user-attachments/assets/a16f4f74-c6b5-4e31-81fa-a949fcdaf1ec">


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
