### PR TITLE
테이블 unique 제약 조건을 활용해 참여 시 동시성 이슈 해결 

### DIFF
--- a/backend/src/main/java/mouda/backend/darakbang/business/DarakbangService.java
+++ b/backend/src/main/java/mouda/backend/darakbang/business/DarakbangService.java
@@ -2,6 +2,7 @@ package mouda.backend.darakbang.business;
 
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,7 +108,12 @@ public class DarakbangService {
 		}
 
 		DarakbangMember entity = request.toEntity(darakbang, member);
-		darakbangMemberRepository.save(entity);
+		try {
+			darakbangMemberRepository.save(entity);
+		} catch (DataIntegrityViolationException exception) {
+			throw new DarakbangMemberException(HttpStatus.BAD_REQUEST,
+				DarakbangMemberErrorMessage.MEMBER_ALREADY_EXIST);
+		}
 
 		return darakbang;
 	}

--- a/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
+++ b/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
@@ -20,7 +20,6 @@ public class Darakbang {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(unique = true)
 	private Long id;
 
 	@Column(nullable = false)

--- a/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
+++ b/backend/src/main/java/mouda/backend/darakbang/domain/Darakbang.java
@@ -20,6 +20,7 @@ public class Darakbang {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(unique = true)
 	private Long id;
 
 	@Column(nullable = false)

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -36,7 +36,6 @@ public class DarakbangMember {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(unique = true)
 	private Long id;
 
 	@JoinColumn(nullable = false)

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -12,6 +12,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,10 +24,19 @@ import mouda.backend.darakbangmember.exception.DarakbangMemberException;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(
+	name = "darakbang_member",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			columnNames = {"member_id", "darakbang_id"}
+		)
+	}
+)
 public class DarakbangMember {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(unique = true)
 	private Long id;
 
 	@JoinColumn(nullable = false)

--- a/backend/src/main/java/mouda/backend/moim/domain/Chamyo.java
+++ b/backend/src/main/java/mouda/backend/moim/domain/Chamyo.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +19,14 @@ import mouda.backend.darakbangmember.domain.DarakbangMember;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(
+	name = "chamyo",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			columnNames = {"moim_id", "darakbang_member_id"}
+		)
+	}
+)
 public class Chamyo {
 
 	@Id

--- a/backend/src/main/java/mouda/backend/moim/infrastructure/MoimRepository.java
+++ b/backend/src/main/java/mouda/backend/moim/infrastructure/MoimRepository.java
@@ -1,15 +1,12 @@
 package mouda.backend.moim.infrastructure;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import jakarta.persistence.LockModeType;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.domain.MoimStatus;
 
@@ -29,8 +26,4 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
 			ORDER BY m.id DESC
 		""")
 	List<Moim> findAllByDarakbangIdOrderByIdDesc(@Param("darakbangId") Long darakbangId);
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("select m from Moim m where m.id = :moimId")
-	Optional<Moim> findByIdForUpdate(@Param("moimId") Long moimId);
 }

--- a/backend/src/test/java/mouda/backend/moim/chamyo/business/ChamyoServiceTest.java
+++ b/backend/src/test/java/mouda/backend/moim/chamyo/business/ChamyoServiceTest.java
@@ -91,7 +91,6 @@ class ChamyoServiceTest {
 				.getDarakbangMemberWithWooteco(darakbang, member);
 			darakbangMemberRepository.save(darakbangMember);
 
-			long startTime = System.currentTimeMillis();
 			for (int i = 0; i < threadCount; i++) {
 				executorService.execute(() -> {
 					try {
@@ -103,9 +102,6 @@ class ChamyoServiceTest {
 			}
 			latch.await();
 			executorService.shutdown();
-
-			long endTime = System.currentTimeMillis();
-			System.out.printf("Test time : %d ms\n", endTime - startTime);
 
 			assertThat(chamyoService.findAllChamyo(darakbang.getId(), moim.getId()).chamyos()).hasSize(1);
 		}

--- a/backend/src/test/java/mouda/backend/moim/chamyo/business/ChamyoServiceTest.java
+++ b/backend/src/test/java/mouda/backend/moim/chamyo/business/ChamyoServiceTest.java
@@ -102,7 +102,6 @@ class ChamyoServiceTest {
 			}
 			latch.await();
 			executorService.shutdown();
-
 			assertThat(chamyoService.findAllChamyo(darakbang.getId(), moim.getId()).chamyos()).hasSize(1);
 		}
 	}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

- 다락방 참여 동시성 이슈 해결
- 모임 참여시 동시성 이슈 해결 방법을 변경
- 동시성 테스트

## 이슈 ID는 무엇인가요?

- #520 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

- 다락방 참여와 모임 참여의 경우, **매핑 테이블** 이라는 조건을 활용해 복합 UNIQUE KEY 제약조건을 걸었습니다.
- 동시성 이슈가 생기면 DataIntegrityViolationException 에러가 터지기 때문에 이를 잡아서 서비스 예외를 던져주었습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->

(참고) unqiue 제약 조건이 아닌 다른 제약 조건에 의해 생긴 DataIntegrityViolationException 에러에 대해서도 (NOT NULL 등 ..) `이미 참여했어요!` 라는 에러를 던지게 됩니다.