### PR TITLE
시간 validate가 내가 선택한 시간을 반영하지 않는 문제 수정

### DIFF
--- a/frontend/src/pages/MoimModifyPage/MoimModifyPage.constant.ts
+++ b/frontend/src/pages/MoimModifyPage/MoimModifyPage.constant.ts
@@ -14,7 +14,7 @@ interface LabeledInputInfo {
   type: string;
   placeholder: string;
   required: boolean;
-  validate?: (value: string) => boolean;
+  validate?: (value1: string, value2?: string) => boolean;
 }
 
 const MOIM_INPUT_INFOS: LabeledInputInfo[] = [
@@ -24,7 +24,7 @@ const MOIM_INPUT_INFOS: LabeledInputInfo[] = [
     type: 'text',
     placeholder: `${POLICES.minimumTitleLength}자 이상 ${POLICES.maximumTitleLength}자 이하로 입력해주세요`,
     required: true,
-    validate: validateTitle, // string 타입
+    validate: validateTitle,
   },
   {
     name: 'date',
@@ -32,7 +32,7 @@ const MOIM_INPUT_INFOS: LabeledInputInfo[] = [
     type: 'date',
     placeholder: '현재 시간 이후로 설정해주세요',
     required: false,
-    validate: validateDate, // string 타입
+    validate: validateDate,
   },
   {
     name: 'time',
@@ -40,7 +40,7 @@ const MOIM_INPUT_INFOS: LabeledInputInfo[] = [
     type: 'time',
     placeholder: '현재 시간 이후로 설정해주세요',
     required: false,
-    validate: validateTime, // string 타입
+    validate: validateTime,
   },
   {
     name: 'place',

--- a/frontend/src/pages/MoimModifyPage/MoimModifyPage.tsx
+++ b/frontend/src/pages/MoimModifyPage/MoimModifyPage.tsx
@@ -43,16 +43,35 @@ export default function MoimModifyPage() {
       </FormLayout.Header>
 
       <FormLayout.MainForm>
-        {MOIM_INPUT_INFOS.map((info) =>
-          info.type === 'textarea' ? (
-            <LabeledTextArea
-              {...info}
-              key={info.title}
-              onChange={handleTextAreaChange}
-              value={inputData[info.name]}
-              validateFun={info?.validate}
-            />
-          ) : (
+        {MOIM_INPUT_INFOS.map((info) => {
+          if (info.type === 'textarea') {
+            return (
+              <LabeledTextArea
+                {...info}
+                key={info.title}
+                onChange={handleTextAreaChange}
+                value={inputData[info.name]}
+                validateFun={info?.validate}
+              />
+            );
+          } else if (info.type === 'time') {
+            return (
+              <LabeledInput
+                {...info}
+                key={info.title}
+                type="time"
+                onChange={handleInputChange}
+                value={inputData[info.name]}
+                validateFun={(time: string) => {
+                  return info?.validate
+                    ? info.validate(time, inputData['date'])
+                    : true;
+                }}
+              />
+            );
+          }
+
+          return (
             <LabeledInput
               {...info}
               key={info.title}
@@ -60,8 +79,8 @@ export default function MoimModifyPage() {
               value={inputData[info.name]}
               validateFun={info?.validate}
             />
-          ),
-        )}
+          );
+        })}
       </FormLayout.MainForm>
 
       <FormLayout.BottomButtonWrapper>

--- a/frontend/src/pages/MoimModifyPage/MoimModifyPage.util.ts
+++ b/frontend/src/pages/MoimModifyPage/MoimModifyPage.util.ts
@@ -13,7 +13,7 @@ export const validateDate = (date: string) => {
   return date >= nowDateYyyymmdd && POLICIES.yyyymmddDashRegex.test(date);
 };
 
-export const validateTime = (time: string) => {
+export const validateTime = (time: string, date?: string) => {
   if (time === '') {
     return true;
   }
@@ -21,18 +21,24 @@ export const validateTime = (time: string) => {
     return false;
   }
 
-  const now = new Date();
-  const [inputHour, inputMinute] = time.split(':').map(Number);
-  const inputTime = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-    inputHour,
-    inputMinute,
-  );
+  console.log(date);
 
-  if (inputTime < now) {
-    return false;
+  if (date !== '') {
+    const dates = date?.split('-').map(Number);
+
+    const now = new Date();
+    const [inputHour, inputMinute] = time.split(':').map(Number);
+    const inputTime = new Date(
+      dates?.[0] ?? now.getFullYear(), // 년도
+      (dates?.[1] ?? now.getMonth() + 1) - 1, // 월
+      dates?.[2] ?? now.getDate(), // 일
+      inputHour,
+      inputMinute,
+    );
+
+    if (inputTime < now) {
+      return false;
+    }
   }
   return true;
 };
@@ -48,9 +54,9 @@ export const validatePlace = (place: string) => {
 };
 export const validateMaxPeople = (maxPeople: number | string) => {
   if (typeof maxPeople === 'string') {
-    maxPeople = Number(maxPeople); // string을 number로 변환
+    maxPeople = Number(maxPeople);
     if (isNaN(maxPeople)) {
-      return false; // 변환이 실패하면 false 반환
+      return false;
     }
   }
 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

현재 모임 수정하기 페이지에서 날짜가 언제인든 시간이 현재 날짜 기준으로
validate가 되어서 시간 설정에 문제가 발생
이를 해결하기위해 시간 validate에 Date도 props로 넘겨 받음

## 이슈 ID는 무엇인가요?

- #537

## 설명
시간만 설정일 경우 에러가 발생하지 않음
<img width="554" alt="image" src="https://github.com/user-attachments/assets/abd7eda0-3f7a-47b8-9d04-c27d2208fc59">

이전 시간을 선택 시, 에러가 발생함
<img width="554" alt="image" src="https://github.com/user-attachments/assets/086f2bf1-7db7-4d87-bcb0-e75d014e4ae1">
 

## 질문 혹은 공유 사항 (Optional)

LabeledInput에 대한 시간에 대한 validateFun이 날짜에 의존하게 되어 구현이 어려웠습니다. 일단 해결하기는 하였으나 코드가 유지보수성이 떨어진다고 생각이 듭니다. 이를 어떻게 해결할 수 있을지 고민입니다. 좋은 아이디어가 있을까요?
