### PR TITLE
MSW환경에서 카카오톡 로그인이 필요한 문제 수정

### DIFF
--- a/frontend/src/apis/endPoints.ts
+++ b/frontend/src/apis/endPoints.ts
@@ -24,7 +24,9 @@ const API_URL = {
   interest: addBaseUrl('/interest', true),
   please: addBaseUrl('/please', true),
   notification: addBaseUrl('/notification', true),
+  kakaoOAuth: addBaseUrl('/auth/kakao/oauth', false),
 };
+
 const ENDPOINTS = {
   moim: 'moim',
   moims: 'moim',

--- a/frontend/src/mocks/handler/moimHandler.ts
+++ b/frontend/src/mocks/handler/moimHandler.ts
@@ -282,4 +282,11 @@ export const moimHandler = [
       },
     });
   }),
+  http.get(API_URL.kakaoOAuth, () => {
+    return HttpResponse.json({
+      data: {
+        accessToken: 1,
+      },
+    });
+  }),
 ];

--- a/frontend/src/service/forgroundMessage.ts
+++ b/frontend/src/service/forgroundMessage.ts
@@ -37,7 +37,7 @@ function initializeForegroundMessageHandling() {
   });
 }
 
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && process.env.MSW !== 'true') {
   navigator.serviceWorker
     .register(`/firebase-messaging-sw.js`)
     .then((registration) => {

--- a/frontend/src/utils/tokenManager.ts
+++ b/frontend/src/utils/tokenManager.ts
@@ -1,13 +1,19 @@
 const TOKEN_KEY = 'access-token';
 
 export const setToken = (token: string): void => {
-  localStorage.setItem(TOKEN_KEY, token);
+  if (process.env.MSW !== 'true') {
+    localStorage.setItem(TOKEN_KEY, token);
+  }
 };
 
 // TODO: token 관리 로직 추가 필요(토큰 존재, 토큰 만료)
 export const getToken = () => {
-  const token = localStorage.getItem(TOKEN_KEY);
-  return token;
+  if (process.env.MSW !== 'true') {
+    const token = localStorage.getItem(TOKEN_KEY);
+    return token;
+  } else {
+    return 'random';
+  }
 };
 
 export const removeToken = (): void => {


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

현재 MSW환경에서 localstorage에 access 토큰 값이 없으면 모킹이 제대로 진행되지 않는 문제가 있습니다. 이것을 해결하기 위한 변경사항입니다.

## 이슈 ID는 무엇인가요?

- #554
## 설명

MSW환경에서 localstorage에 access 토큰 값이 없으면 모킹이 제대로 진행되지 않는 문제가 있습니다. 이것을 해결하기 위해 msw환경에서는 localStorage에서 가져오는 값을 고정하여 이 문제를 해결했습니다.
수정하는 도중에 서비스 워커 관련 에러가 발생하는 것을 확인하였습니다.
현재 서비스워커 코드 파일이, msw와 firebase 2개를 사용하고 있습니다.
하지만 브라우저는 동일한 스코프(scope)에 두 개의 서비스 워커를 허용하지 않기 때문에 충돌이 발생합니다.
이를 1차적으로 막기 위해서 msw환경에서는 firebase를 사용할 수 없게 막아두었습니다. 
후에 msw환경에서도 firebase를 이용하기 싶으면 추가적인 조치가 필요해 보인다.
## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
