### PR TITLE
MASTER - SLAVE 적용을 위한 Springboot 설정 추가

### DIFF
--- a/backend/src/main/java/mouda/backend/common/config/data/DataSourceConfiguration.java
+++ b/backend/src/main/java/mouda/backend/common/config/data/DataSourceConfiguration.java
@@ -1,0 +1,85 @@
+package mouda.backend.common.config.data;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+
+@Profile(value = "prod")
+@Configuration
+public class DataSourceConfiguration {
+
+    public static final String MASTER_DATA_SOURCE = "MASTER";
+    public static final String SLAVE_DATA_SOURCE = "SLAVE";
+    public static final String ROUTING_DATA_SOURCE = "ROUTING";
+
+    @Value("${spring.jpa.hibernate.ddl-auto}")
+    private String hibernateDdlAuto;
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            EntityManagerFactoryBuilder builder, DataSource dataSource
+    ) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.hbm2ddl.auto", hibernateDdlAuto);
+
+        return builder.dataSource(dataSource)
+                .properties(properties)
+                .packages("mouda.backend.*.domain")
+                .build();
+    }
+
+    @Primary
+    @DependsOn(ROUTING_DATA_SOURCE)
+    @Bean
+    public DataSource dataSource(@Qualifier(ROUTING_DATA_SOURCE) DataSource dataSource) {
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+
+    @DependsOn({MASTER_DATA_SOURCE, SLAVE_DATA_SOURCE})
+    @Bean(ROUTING_DATA_SOURCE)
+    public DataSource routingDataSource(
+            @Qualifier(MASTER_DATA_SOURCE) DataSource masterDataSource,
+            @Qualifier(SLAVE_DATA_SOURCE) DataSource slaveDataSource
+    ) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        Map<Object, Object> dataSources = Map.of(
+                MASTER_DATA_SOURCE, masterDataSource,
+                SLAVE_DATA_SOURCE, slaveDataSource
+        );
+
+        routingDataSource.setTargetDataSources(dataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean(MASTER_DATA_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(SLAVE_DATA_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.slave.hikari")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/mouda/backend/common/config/data/RoutingDataSource.java
+++ b/backend/src/main/java/mouda/backend/common/config/data/RoutingDataSource.java
@@ -1,0 +1,15 @@
+package mouda.backend.common.config.data;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DataSourceConfiguration.SLAVE_DATA_SOURCE;
+        }
+        return DataSourceConfiguration.MASTER_DATA_SOURCE;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
   profiles:
     active:
       - local
+  jpa:
+    open-in-view: false
 
 security:
   jwt:

--- a/backend/src/test/java/mouda/backend/common/config/NoTransactionExtension.java
+++ b/backend/src/test/java/mouda/backend/common/config/NoTransactionExtension.java
@@ -24,6 +24,10 @@ public class NoTransactionExtension implements BeforeEachCallback {
 	}
 
 	private static void validateTransactionalAnnotationExists(ExtensionContext extensionContext) {
+		if (TestContextAnnotationUtils.hasAnnotation(extensionContext.getRequiredTestClass(), WithTransactionalTest.class)) {
+			return;
+		}
+
 		if (TestContextAnnotationUtils.hasAnnotation(extensionContext.getRequiredTestClass(), Transactional.class) ||
 			TestContextAnnotationUtils.hasAnnotation(extensionContext.getRequiredTestClass(),
 				jakarta.transaction.Transactional.class)) {

--- a/backend/src/test/java/mouda/backend/common/config/WithTransactionalTest.java
+++ b/backend/src/test/java/mouda/backend/common/config/WithTransactionalTest.java
@@ -1,0 +1,11 @@
+package mouda.backend.common.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface WithTransactionalTest {
+}

--- a/backend/src/test/java/mouda/backend/common/config/data/RoutingDataSourceTest.java
+++ b/backend/src/test/java/mouda/backend/common/config/data/RoutingDataSourceTest.java
@@ -1,0 +1,58 @@
+package mouda.backend.common.config.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import mouda.backend.common.config.WithTransactionalTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@WithTransactionalTest
+class RoutingDataSourceTest {
+
+    private RoutingDataSource routingDataSource;
+
+    @BeforeEach
+    void setUp() {
+        DataSource masterDataSource = mock(DataSource.class);
+        DataSource slaveDataSource = mock(DataSource.class);
+
+        Map<Object, Object> dataSources = new HashMap<>();
+        dataSources.put(DataSourceConfiguration.MASTER_DATA_SOURCE, masterDataSource);
+        dataSources.put(DataSourceConfiguration.SLAVE_DATA_SOURCE, slaveDataSource);
+
+        routingDataSource = new RoutingDataSource();
+        routingDataSource.setTargetDataSources(dataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+    }
+
+    @DisplayName("@Transactional이 readOnly가 아니면 Master DataSource로 라우팅한다.")
+    @Test
+    @Transactional
+    void routeToMasterDataSource() {
+        Object lookupKey = routingDataSource.determineCurrentLookupKey();
+        assertThat(lookupKey).isEqualTo(DataSourceConfiguration.MASTER_DATA_SOURCE);
+    }
+
+    @DisplayName("@Transactional이 readOnly 이면 Slave DataSource로 라우팅한다.")
+    @Test
+    @Transactional(readOnly = true)
+    void routeToSlaveDataSource() {
+        Object lookupKey = routingDataSource.determineCurrentLookupKey();
+        assertThat(lookupKey).isEqualTo(DataSourceConfiguration.SLAVE_DATA_SOURCE);
+    }
+
+    @DisplayName("@Transactional이 없는 경우 기본적으로 Master DataSource로 라우팅한다.")
+    @Test
+    void routeToMasterDataSource_WhenNoTransactionalExist() {
+        Object lookupKey = routingDataSource.determineCurrentLookupKey();
+        assertThat(lookupKey).isEqualTo(DataSourceConfiguration.MASTER_DATA_SOURCE);
+    }
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

- MASTER - SLAVE 적용을 위한 Springboot 설정 추가

## 이슈 ID는 무엇인가요?

- #561 

## 설명

금일 회의에서 Springboot가 실행되지 않았던 이유는 DataSource를 여러개(Master, Slave) 등록하는 것에 대한 EntityManagerFactory 빈 등록이 없었기 때문이라 추정하였고, 따라서 EntityManagerFactory 빈을 등록하는 코드를 추가하여 해결하였습니다.

EC2에서 직접 ddl-auto를 create로 지정한 뒤 실행하여 테이블 생성 및 정상 작동은 확인하였으니 이제 기존 DB에 있는 데이터만 옮기면 될 것 같습니다.


## 질문 혹은 공유 사항 (Optional)

Profile("prod")가 붙은 Configuration에 대한 테스트는 진행하지 못했으나, Transactional에 따른 DataSource 지정에 대한 테스트는 작성했습니다.(`RoutingDataSourceTest`).

이 테스트를 위해서는 테스트 메서드에 Transactional을 지정할 수 밖에 없기에, 기존의 NoTransactionExtension과의 충돌을 방지하고자 WithTransactionalTest라는 별도의 어노테이션을 만들고 처리했어요. 

참고: [블로그](https://velog.io/@haeyon098/Spring-multi-datasource-%EA%B5%AC%EC%84%B1)