### PR TITLE
fix: 안내면진다 조회시 당첨자 가져오도록 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
@@ -19,65 +19,66 @@ import mouda.backend.bet.infrastructure.BetRepository;
 @RequiredArgsConstructor
 public class BetFinder {
 
-    private final BetDarakbangMemberRepository betDarakbangMemberRepository;
-    private final BetRepository betRepository;
-    private final ParticipantFinder participantFinder;
+	private final BetDarakbangMemberRepository betDarakbangMemberRepository;
+	private final BetRepository betRepository;
+	private final ParticipantFinder participantFinder;
 
-    public Bet find(long darakbangId, long betEntityId) {
-        BetEntity betEntity = betRepository.findByIdAndDarakbangId(betEntityId, darakbangId)
-            .orElseThrow(IllegalArgumentException::new);
-        List<Participant> participants = participantFinder.findAllByBetEntity(betEntity);
+	public Bet find(long darakbangId, long betEntityId) {
+		BetEntity betEntity = betRepository.findByIdAndDarakbangId(betEntityId, darakbangId)
+			.orElseThrow(IllegalArgumentException::new);
+		List<Participant> participants = participantFinder.findAllByBetEntity(betEntity);
 
-        return Bet.builder()
-            .betDetails(betEntity.toBetDetails())
-            .moimerId(betEntity.getMoimerId())
-            .participants(participants)
-            .build();
-    }
+		return Bet.builder()
+			.betDetails(betEntity.toBetDetails())
+			.moimerId(betEntity.getMoimerId())
+			.participants(participants)
+			.loserId(betEntity.getLoserDarakbangMemberId())
+			.build();
+	}
 
-    public List<Bet> findAllByDarakbangId(long darakbangId) {
-        List<BetEntity> betEntities = betRepository.findAllByDarakbangId(darakbangId);
+	public List<Bet> findAllByDarakbangId(long darakbangId) {
+		List<BetEntity> betEntities = betRepository.findAllByDarakbangId(darakbangId);
 
-        return createBets(betEntities);
-    }
+		return createBets(betEntities);
+	}
 
-    public List<Bet> findAllDrawableBet() {
-        List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(
-            LocalDateTime.now().withSecond(0).withNano(0));
+	public List<Bet> findAllDrawableBet() {
+		List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(
+			LocalDateTime.now().withSecond(0).withNano(0));
 
-        return createBets(betEntities);
-    }
+		return createBets(betEntities);
+	}
 
-    private List<Bet> createBets(List<BetEntity> betEntities) {
-        return betEntities.stream()
-            .map(this::createBet).toList();
-    }
+	private List<Bet> createBets(List<BetEntity> betEntities) {
+		return betEntities.stream()
+			.map(this::createBet).toList();
+	}
 
-    private Bet createBet(BetEntity betEntity) {
-        List<Participant> participants = participantFinder.findAllByBetEntity(betEntity);
-        return Bet.builder()
-            .betDetails(betEntity.toBetDetails())
-            .moimerId(betEntity.getMoimerId())
-            .loserId(betEntity.getLoserDarakbangMemberId())
-            .participants(participants)
-            .build();
-    }
+	private Bet createBet(BetEntity betEntity) {
+		List<Participant> participants = participantFinder.findAllByBetEntity(betEntity);
+		return Bet.builder()
+			.betDetails(betEntity.toBetDetails())
+			.moimerId(betEntity.getMoimerId())
+			.loserId(betEntity.getLoserDarakbangMemberId())
+			.participants(participants)
+			.build();
+	}
 
-    @Transactional(readOnly = true)
-    public Loser findResult(long darakbangId, long betId) {
-        // TODO : 예외처리 공통화
-        BetEntity betEntity = betRepository.findByIdAndDarakbangId(betId, darakbangId)
-            .orElseThrow(IllegalArgumentException::new);
+	@Transactional(readOnly = true)
+	public Loser findResult(long darakbangId, long betId) {
+		// TODO : 예외처리 공통화
+		BetEntity betEntity = betRepository.findByIdAndDarakbangId(betId, darakbangId)
+			.orElseThrow(IllegalArgumentException::new);
 
-        // TODO : 리팩토링
-        Long loserDarakbangMemberId = betEntity.getLoserDarakbangMemberId();
-        if (loserDarakbangMemberId == null) {
-            throw new IllegalArgumentException("아직 추첨이 진행되지 않았습니다.");
-        }
+		// TODO : 리팩토링
+		Long loserDarakbangMemberId = betEntity.getLoserDarakbangMemberId();
+		if (loserDarakbangMemberId == null) {
+			throw new IllegalArgumentException("아직 추첨이 진행되지 않았습니다.");
+		}
 
-        BetDarakbangMemberEntity betDarakbangMemberEntity = betDarakbangMemberRepository.findByBetIdAndDarakbangMemberId(
-            betId, loserDarakbangMemberId).orElseThrow(IllegalArgumentException::new);
-        return new Loser(betDarakbangMemberEntity.getDarakbangMember().getId(),
-            betDarakbangMemberEntity.getDarakbangMember().getNickname());
-    }
+		BetDarakbangMemberEntity betDarakbangMemberEntity = betDarakbangMemberRepository.findByBetIdAndDarakbangMemberId(
+			betId, loserDarakbangMemberId).orElseThrow(IllegalArgumentException::new);
+		return new Loser(betDarakbangMemberEntity.getDarakbangMember().getId(),
+			betDarakbangMemberEntity.getDarakbangMember().getNickname());
+	}
 }

--- a/backend/src/test/java/mouda/backend/bet/business/BetServiceTest.java
+++ b/backend/src/test/java/mouda/backend/bet/business/BetServiceTest.java
@@ -21,6 +21,7 @@ import mouda.backend.bet.infrastructure.BetRepository;
 import mouda.backend.bet.presentation.request.BetCreateRequest;
 import mouda.backend.bet.presentation.response.BetFindAllResponse;
 import mouda.backend.bet.presentation.response.BetFindAllResponses;
+import mouda.backend.bet.presentation.response.BetFindResponse;
 import mouda.backend.common.fixture.BetEntityFixture;
 import mouda.backend.common.fixture.DarakbangSetUp;
 import mouda.backend.darakbangmember.infrastructure.DarakbangMemberRepository;
@@ -28,91 +29,125 @@ import mouda.backend.darakbangmember.infrastructure.DarakbangMemberRepository;
 @SpringBootTest
 class BetServiceTest extends DarakbangSetUp {
 
-    @Autowired
-    BetService betService;
+	@Autowired
+	BetService betService;
 
-    @Autowired
-    BetWriter betWriter;
+	@Autowired
+	BetWriter betWriter;
 
-    @Autowired
-    BetRepository betRepository;
+	@Autowired
+	BetRepository betRepository;
 
-    @Autowired
-    BetDarakbangMemberRepository betDarakbangMemberRepository;
+	@Autowired
+	BetDarakbangMemberRepository betDarakbangMemberRepository;
 
-    @Autowired
-    DarakbangMemberRepository darakbangMemberRepository;
+	@Autowired
+	DarakbangMemberRepository darakbangMemberRepository;
 
-    @DisplayName("조회된 안내면진다는 정렬되어있다.")
-    @Test
-    void findAll() {
-        // given
-        long darakbangId = darakbang.getId();
-        BetEntity betEntity1 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(), LocalDateTime.now().plusMinutes(5));
-        BetEntity betEntity2 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(), LocalDateTime.now().minusMinutes(3));
-        BetEntity betEntity3 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(), LocalDateTime.now().plusMinutes(10));
+	@DisplayName("조회된 안내면진다는 정렬되어있다.")
+	@Test
+	void findAll() {
+		// given
+		long darakbangId = darakbang.getId();
+		BetEntity betEntity1 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(),
+			LocalDateTime.now().plusMinutes(5));
+		BetEntity betEntity2 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(),
+			LocalDateTime.now().minusMinutes(3));
+		BetEntity betEntity3 = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(),
+			LocalDateTime.now().plusMinutes(10));
 
-        BetEntity savedBetEntity1 = betRepository.save(betEntity1);
-        BetEntity savedBetEntity2 = betRepository.save(betEntity2);
-        BetEntity savedBetEntity3 = betRepository.save(betEntity3);
+		BetEntity savedBetEntity1 = betRepository.save(betEntity1);
+		BetEntity savedBetEntity2 = betRepository.save(betEntity2);
+		BetEntity savedBetEntity3 = betRepository.save(betEntity3);
 
-        // when
-        BetFindAllResponses findAllResponses = betService.findAllBets(darakbangId);
+		// when
+		BetFindAllResponses findAllResponses = betService.findAllBets(darakbangId);
 
-        // then
-        List<Long> expectedOrder = Arrays.asList(savedBetEntity2.getId(), savedBetEntity1.getId(), savedBetEntity3.getId());
-        List<Long> actualOrder = findAllResponses.bets().stream()
-            .map(BetFindAllResponse::id)
-            .toList();
+		// then
+		List<Long> expectedOrder = Arrays.asList(savedBetEntity2.getId(), savedBetEntity1.getId(),
+			savedBetEntity3.getId());
+		List<Long> actualOrder = findAllResponses.bets().stream()
+			.map(BetFindAllResponse::id)
+			.toList();
 
-        assertThat(actualOrder).isEqualTo(expectedOrder);
-    }
+		assertThat(actualOrder).isEqualTo(expectedOrder);
+	}
 
-    @DisplayName("새로운 안내면진다를 생성한다.")
-    @Test
-    void createBet() {
-        // given
-        BetCreateRequest betRequest = new BetCreateRequest("테니바보", 10);
-        // when
-        long createdBetId = betService.createBet(1L, betRequest, darakbangHogee);
-        //then
-        assertThat(createdBetId).isEqualTo(1L);
-    }
+	@DisplayName("추첨하지 않은 안내면진다를 상세 조회한다.")
+	@Test
+	void findNotDrawnBet() {
+		// given
+		long darakbangId = darakbang.getId();
+		BetEntity drawnBetEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity savedBetEntity = betRepository.save(drawnBetEntity);
 
-    @DisplayName("안내면진다에 참여한다.")
-    @Test
-    void participateBet() {
-        // given
-        long darakbangId = 1L;
-        BetCreateRequest betRequest = new BetCreateRequest("테니바보", 10);
-        Bet bet = betRequest.toBet(2L);
-        BetEntity betEntity = betRepository.save(BetEntity.create(bet, darakbangId));
+		// when
+		BetFindResponse bet = betService.findBet(darakbangId, savedBetEntity.getId(), darakbangAnna);
 
-        long betId = betEntity.getId();
+		// then
+		assertThat(bet.isAnnounced()).isFalse();
+	}
 
-        // when
-        betService.participateBet(darakbangId, betId, darakbangHogee);
+	@DisplayName("추첨한 안내면진다를 상세 조회한다.")
+	@Test
+	void findDrawnBet() {
+		// given
+		long darakbangId = darakbang.getId();
+		BetEntity drawnBetEntity = BetEntityFixture.getDrawedBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity savedBetEntity = betRepository.save(drawnBetEntity);
 
-        //then
-        List<BetDarakbangMemberEntity> entities = betDarakbangMemberRepository.findAll();
-        assertThat(entities).hasSize(1);
-    }
+		// when
+		BetFindResponse bet = betService.findBet(darakbangId, savedBetEntity.getId(), darakbangAnna);
 
-    @DisplayName("당첨자를 강제추첨한다.")
-    @Test
-    void drawBet() {
-        // given
-        Long darakbangId = darakbang.getId();
-        BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
-        BetEntity savedBetEntity = betRepository.save(betEntity);
-        betWriter.participate(darakbangId, savedBetEntity.getId(), darakbangAnna);
+		// then
+		assertThat(bet.isAnnounced()).isTrue();
+	}
 
-        // when
-        betService.drawBet(darakbangId, savedBetEntity.getId());
+	@DisplayName("새로운 안내면진다를 생성한다.")
+	@Test
+	void createBet() {
+		// given
+		BetCreateRequest betRequest = new BetCreateRequest("테니바보", 10);
+		// when
+		long createdBetId = betService.createBet(1L, betRequest, darakbangHogee);
+		//then
+		assertThat(createdBetId).isEqualTo(1L);
+	}
 
-        //then
-        Optional<BetEntity> drawnBetEntity = betRepository.findById(savedBetEntity.getId());
-        assertThat(drawnBetEntity).isPresent();
-        assertThat(drawnBetEntity.get().getLoserDarakbangMemberId()).isNotNull();
-    }
+	@DisplayName("안내면진다에 참여한다.")
+	@Test
+	void participateBet() {
+		// given
+		long darakbangId = 1L;
+		BetCreateRequest betRequest = new BetCreateRequest("테니바보", 10);
+		Bet bet = betRequest.toBet(2L);
+		BetEntity betEntity = betRepository.save(BetEntity.create(bet, darakbangId));
+
+		long betId = betEntity.getId();
+
+		// when
+		betService.participateBet(darakbangId, betId, darakbangHogee);
+
+		//then
+		List<BetDarakbangMemberEntity> entities = betDarakbangMemberRepository.findAll();
+		assertThat(entities).hasSize(1);
+	}
+
+	@DisplayName("당첨자를 강제추첨한다.")
+	@Test
+	void drawBet() {
+		// given
+		Long darakbangId = darakbang.getId();
+		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity savedBetEntity = betRepository.save(betEntity);
+		betWriter.participate(darakbangId, savedBetEntity.getId(), darakbangAnna);
+
+		// when
+		betService.drawBet(darakbangId, savedBetEntity.getId());
+
+		//then
+		Optional<BetEntity> drawnBetEntity = betRepository.findById(savedBetEntity.getId());
+		assertThat(drawnBetEntity).isPresent();
+		assertThat(drawnBetEntity.get().getLoserDarakbangMemberId()).isNotNull();
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

안내면진다 상세조회 API에서 `isAnnounced` 필드가 항상 false 인 문제를 해결했습니다.

## 이슈 ID는 무엇인가요?

- closed #601 

## 설명

Builder를 사용하며 필드를 놓친 게 원인이었습니다.
기존 인덴트가 달라 변경사항이 큰데 수정 지점은 아래 하나입니다

변경 후
```java
return Bet.builder()
	.betDetails(betEntity.toBetDetails())
	.moimerId(betEntity.getMoimerId())
	.participants(participants)
	.loserId(betEntity.getLoserDarakbangMemberId())
	.build();
```

기존에 빠진 loseId 를 추가했습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
