### PR TITLE
구버전 Chat 기능과 신버전 Chat 기능 호환성 문제 해결 & 배팅 디테일 조회 실패 문제 해결

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/domain/Bet.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/Bet.java
@@ -41,7 +41,7 @@ public class Bet {
 		if (isParticipated(id)) {
 			return BetRole.MOIMEE;
 		}
-		return BetRole.NON_PARTICIPANT;
+		return BetRole.NON_MOIMEE;
 	}
 
 	private boolean isParticipated(Long id) {

--- a/backend/src/main/java/mouda/backend/bet/domain/BetRole.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BetRole.java
@@ -1,5 +1,5 @@
 package mouda.backend.bet.domain;
 
 public enum BetRole {
-	MOIMER, MOIMEE, NON_PARTICIPANT
+	MOIMER, MOIMEE, NON_MOIMEE
 }

--- a/backend/src/main/java/mouda/backend/chat/presentation/controller/ChatController.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/controller/ChatController.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import mouda.backend.aop.logging.ExceptRequestLogging;
 import mouda.backend.chat.business.ChatService;
 import mouda.backend.chat.domain.ChatRoomType;
-import mouda.backend.chat.presentation.controller.swagger.ChatSwagger;
 import mouda.backend.chat.presentation.request.ChatCreateRequest;
 import mouda.backend.chat.presentation.request.DateTimeConfirmRequest;
 import mouda.backend.chat.presentation.request.LastReadChatRequest;
@@ -32,11 +31,11 @@ import mouda.backend.darakbangmember.domain.DarakbangMember;
 @RestController
 @RequestMapping("/v1/darakbang/{darakbangId}/chatroom")
 @RequiredArgsConstructor
-public class ChatController implements ChatSwagger {
+public class ChatController {
 
 	private final ChatService chatService;
 
-	@Override
+	// @override
 	@PostMapping("/{chatRoomId}")
 	public ResponseEntity<Void> createChat(
 		@PathVariable Long darakbangId,
@@ -49,7 +48,7 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok().build();
 	}
 
-	@Override
+	// @override
 	@ExceptRequestLogging
 	@GetMapping("/{chatRoomId}")
 	public ResponseEntity<RestResponse<ChatFindUnloadedResponse>> findUnloadedChats(
@@ -64,7 +63,7 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok(new RestResponse<>(unloadedChats));
 	}
 
-	@Override
+	// @override
 	@GetMapping("/preview")
 	@ExceptRequestLogging
 	public ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
@@ -77,7 +76,7 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok(new RestResponse<>(chatPreviewResponses));
 	}
 
-	@Override
+	// @override
 	@PostMapping("/{chatRoomId}/last")
 	public ResponseEntity<Void> createLastReadChatId(
 		@PathVariable Long darakbangId,
@@ -90,7 +89,7 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok().build();
 	}
 
-	@Override
+	// @override
 	@PostMapping("/{chatRoomId}/datetime")
 	public ResponseEntity<Void> confirmDateTime(
 		@PathVariable Long darakbangId,
@@ -103,7 +102,7 @@ public class ChatController implements ChatSwagger {
 		return ResponseEntity.ok().build();
 	}
 
-	@Override
+	// @override
 	@PostMapping("/{chatRoomId}/place")
 	public ResponseEntity<Void> confirmPlace(
 		@PathVariable Long darakbangId,

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatPreviewResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatPreviewResponse.java
@@ -6,7 +6,7 @@ import mouda.backend.chat.domain.Target;
 
 @Builder
 public record ChatPreviewResponse(
-	Long targetId,
+	Long chatRoomId,
 	String title,
 	int currentPeople,
 	boolean isStarted,
@@ -17,7 +17,7 @@ public record ChatPreviewResponse(
 	public static ChatPreviewResponse toResponse(ChatPreview chatPreview) {
 		Target target = chatPreview.getTarget();
 		return ChatPreviewResponse.builder()
-			.targetId(target.getTargetId())
+			.chatRoomId(chatPreview.getChatRoom().getId())
 			.title(target.getTitle())
 			.isStarted(target.isStarted())
 			.currentPeople(chatPreview.getCurrentPeople())

--- a/backend/src/main/java/mouda/backend/moim/business/ChatService.java
+++ b/backend/src/main/java/mouda/backend/moim/business/ChatService.java
@@ -21,12 +21,12 @@ import mouda.backend.moim.implement.finder.MoimFinder;
 import mouda.backend.moim.implement.validator.ChamyoValidator;
 import mouda.backend.moim.implement.writer.ChatWriter;
 import mouda.backend.moim.implement.writer.MoimWriter;
-import mouda.backend.moim.presentation.request.chat.ChatCreateRequest;
-import mouda.backend.moim.presentation.request.chat.DateTimeConfirmRequest;
-import mouda.backend.moim.presentation.request.chat.LastReadChatRequest;
-import mouda.backend.moim.presentation.request.chat.PlaceConfirmRequest;
-import mouda.backend.moim.presentation.response.chat.ChatFindUnloadedResponse;
-import mouda.backend.moim.presentation.response.chat.ChatPreviewResponses;
+import mouda.backend.moim.presentation.request.chat.OldChatCreateRequest;
+import mouda.backend.moim.presentation.request.chat.OldDateTimeConfirmRequest;
+import mouda.backend.moim.presentation.request.chat.OldLastReadChatRequest;
+import mouda.backend.moim.presentation.request.chat.OldPlaceConfirmRequest;
+import mouda.backend.moim.presentation.response.chat.OldChatFindUnloadedResponse;
+import mouda.backend.moim.presentation.response.chat.OldChatPreviewResponses;
 import mouda.backend.notification.business.NotificationService;
 import mouda.backend.notification.domain.NotificationType;
 
@@ -44,18 +44,18 @@ public class ChatService {
 	private final ChamyoFinder chamyoFinder;
 	private final ChatRoomFinder chatRoomFinder;
 
-	public void createChat(long darakbangId, ChatCreateRequest chatCreateRequest, DarakbangMember darakbangMember) {
-		Moim moim = moimFinder.read(chatCreateRequest.moimId(), darakbangId);
+	public void createChat(long darakbangId, OldChatCreateRequest oldChatCreateRequest, DarakbangMember darakbangMember) {
+		Moim moim = moimFinder.read(oldChatCreateRequest.moimId(), darakbangId);
 		chamyoValidator.validateMemberChamyoMoim(moim, darakbangMember);
 
-		Chat chat = chatCreateRequest.toEntity(moim, darakbangMember);
+		Chat chat = oldChatCreateRequest.toEntity(moim, darakbangMember);
 		chatWriter.save(chat);
 
 		notificationService.notifyToMembers(NotificationType.NEW_CHAT, darakbangId, moim, darakbangMember);
 	}
 
 	@Transactional(readOnly = true)
-	public ChatFindUnloadedResponse findUnloadedChats(
+	public OldChatFindUnloadedResponse findUnloadedChats(
 		long darakbangId, long recentChatId, long moimId, DarakbangMember darakbangMember
 	) {
 		Moim moim = moimFinder.read(moimId, darakbangId);
@@ -64,11 +64,11 @@ public class ChatService {
 		Chats chats = chatFinder.readAllUnloadedChats(moimId, recentChatId);
 		List<ChatWithAuthor> chatWithAuthors = chats.getChatsWithAuthor(darakbangMember);
 
-		return ChatFindUnloadedResponse.toResponse(chatWithAuthors);
+		return OldChatFindUnloadedResponse.toResponse(chatWithAuthors);
 	}
 
 	public void confirmPlace(
-		long darakbangId, PlaceConfirmRequest request, DarakbangMember darakbangMember
+		long darakbangId, OldPlaceConfirmRequest request, DarakbangMember darakbangMember
 	) {
 		Moim moim = moimFinder.read(request.moimId(), darakbangId);
 		moimWriter.confirmPlace(moim, darakbangMember, request.place());
@@ -80,7 +80,7 @@ public class ChatService {
 	}
 
 	public void confirmDateTime(
-		long darakbangId, DateTimeConfirmRequest request, DarakbangMember darakbangMember
+		long darakbangId, OldDateTimeConfirmRequest request, DarakbangMember darakbangMember
 	) {
 		Moim moim = moimFinder.read(request.moimId(), darakbangId);
 		moimWriter.confirmDateTime(moim, darakbangMember, request.date(), request.time());
@@ -91,20 +91,20 @@ public class ChatService {
 		notificationService.notifyToMembers(NotificationType.MOIM_TIME_CONFIRMED, darakbangId, moim, darakbangMember);
 	}
 
-	public ChatPreviewResponses findChatPreview(long darakbangId, DarakbangMember darakbangMember) {
+	public OldChatPreviewResponses findChatPreview(long darakbangId, DarakbangMember darakbangMember) {
 		ChatRooms chatRooms = chatRoomFinder.findAllOrderByLastChat(darakbangId, darakbangMember);
 		List<MoimChat> moimChats = chatRooms.getMoimChats();
 
-		return ChatPreviewResponses.toResponse(moimChats);
+		return OldChatPreviewResponses.toResponse(moimChats);
 	}
 
 	public void createLastChat(
-		long darakbangId, long moimId, LastReadChatRequest lastReadChatRequest, DarakbangMember darakbangMember
+		long darakbangId, long moimId, OldLastReadChatRequest oldLastReadChatRequest, DarakbangMember darakbangMember
 	) {
 		Moim moim = moimFinder.read(moimId, darakbangId);
 		Chamyo chamyo = chamyoFinder.read(moim, darakbangMember);
 
-		chamyo.updateLastChat(lastReadChatRequest.lastReadChatId());
+		chamyo.updateLastChat(oldLastReadChatRequest.lastReadChatId());
 	}
 
 	public void openChatRoom(Long darakbangId, Long moimId, DarakbangMember darakbangMember) {

--- a/backend/src/main/java/mouda/backend/moim/presentation/controller/swagger/ChatSwagger.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/controller/swagger/ChatSwagger.java
@@ -8,15 +8,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import mouda.backend.chat.presentation.response.ChatFindUnloadedResponse;
 import mouda.backend.common.config.argumentresolver.LoginDarakbangMember;
 import mouda.backend.common.response.RestResponse;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.presentation.request.chat.ChatCreateRequest;
-import mouda.backend.moim.presentation.request.chat.DateTimeConfirmRequest;
-import mouda.backend.moim.presentation.request.chat.LastReadChatRequest;
-import mouda.backend.moim.presentation.request.chat.PlaceConfirmRequest;
-import mouda.backend.moim.presentation.response.chat.ChatFindUnloadedResponse;
-import mouda.backend.moim.presentation.response.chat.ChatPreviewResponses;
+import mouda.backend.moim.presentation.request.chat.OldChatCreateRequest;
+import mouda.backend.moim.presentation.request.chat.OldDateTimeConfirmRequest;
+import mouda.backend.moim.presentation.request.chat.OldLastReadChatRequest;
+import mouda.backend.moim.presentation.request.chat.OldPlaceConfirmRequest;
+import mouda.backend.moim.presentation.response.chat.OldChatPreviewResponses;
 
 public interface ChatSwagger {
 
@@ -27,7 +27,7 @@ public interface ChatSwagger {
 	ResponseEntity<Void> createChat(
 		@PathVariable Long darakbangId,
 		@LoginDarakbangMember DarakbangMember member,
-		@RequestBody ChatCreateRequest chatCreateRequest
+		@RequestBody OldChatCreateRequest oldChatCreateRequest
 	);
 
 	@Operation(summary = "채팅 조회", description = "아직 조회되지 않은 채팅 내역을 조회한다.")
@@ -48,7 +48,7 @@ public interface ChatSwagger {
 	ResponseEntity<Void> confirmPlace(
 		@PathVariable Long darakbangId,
 		@LoginDarakbangMember DarakbangMember member,
-		@RequestBody PlaceConfirmRequest placeConfirmRequest
+		@RequestBody OldPlaceConfirmRequest oldPlaceConfirmRequest
 	);
 
 	@Operation(summary = "날짜 시간 확정", description = "작성자가 날짜와 시간을 확정하는 채팅을 전송합니다.")
@@ -58,14 +58,14 @@ public interface ChatSwagger {
 	ResponseEntity<Void> confirmDateTime(
 		@PathVariable Long darakbangId,
 		@LoginDarakbangMember DarakbangMember member,
-		@RequestBody DateTimeConfirmRequest dateTimeConfirmRequest
+		@RequestBody OldDateTimeConfirmRequest oldDateTimeConfirmRequest
 	);
 
 	@Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회한다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "채팅방 조회 성공!")
 	})
-	ResponseEntity<RestResponse<ChatPreviewResponses>> findChatPreviews(
+	ResponseEntity<RestResponse<OldChatPreviewResponses>> findChatPreviews(
 		@PathVariable Long darakbangId,
 		@LoginDarakbangMember DarakbangMember member
 	);
@@ -77,7 +77,7 @@ public interface ChatSwagger {
 	ResponseEntity<Void> createLastReadChatId(
 		@PathVariable Long darakbangId,
 		@LoginDarakbangMember DarakbangMember member,
-		@RequestBody LastReadChatRequest lastReadChatRequest
+		@RequestBody OldLastReadChatRequest oldLastReadChatRequest
 	);
 
 	@Operation(summary = "채팅방 열기", description = "채팅방을 연다!")

--- a/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldChatCreateRequest.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldChatCreateRequest.java
@@ -10,7 +10,7 @@ import mouda.backend.moim.domain.Chat;
 import mouda.backend.moim.domain.ChatType;
 import mouda.backend.moim.domain.Moim;
 
-public record ChatCreateRequest(
+public record OldChatCreateRequest(
 	@NotNull
 	Long moimId,
 

--- a/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldDateTimeConfirmRequest.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldDateTimeConfirmRequest.java
@@ -9,7 +9,7 @@ import mouda.backend.moim.domain.Chat;
 import mouda.backend.moim.domain.ChatType;
 import mouda.backend.moim.domain.Moim;
 
-public record DateTimeConfirmRequest(
+public record OldDateTimeConfirmRequest(
 	@NotNull
 	Long moimId,
 

--- a/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldLastReadChatRequest.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldLastReadChatRequest.java
@@ -2,7 +2,7 @@ package mouda.backend.moim.presentation.request.chat;
 
 import jakarta.validation.constraints.NotNull;
 
-public record LastReadChatRequest(
+public record OldLastReadChatRequest(
 	@NotNull
 	Long moimId,
 

--- a/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldPlaceConfirmRequest.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/request/chat/OldPlaceConfirmRequest.java
@@ -10,7 +10,7 @@ import mouda.backend.moim.domain.Chat;
 import mouda.backend.moim.domain.ChatType;
 import mouda.backend.moim.domain.Moim;
 
-public record PlaceConfirmRequest(
+public record OldPlaceConfirmRequest(
 	@NotNull
 	Long moimId,
 

--- a/backend/src/main/java/mouda/backend/moim/presentation/response/chat/OldChatFindUnloadedResponse.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/response/chat/OldChatFindUnloadedResponse.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 import mouda.backend.moim.domain.ChatWithAuthor;
 
-public record ChatFindUnloadedResponse(
+public record OldChatFindUnloadedResponse(
 	List<ChatFindDetailResponse> chats
 ) {
-	public static ChatFindUnloadedResponse toResponse(List<ChatWithAuthor> chatWithAuthors) {
+	public static OldChatFindUnloadedResponse toResponse(List<ChatWithAuthor> chatWithAuthors) {
 		List<ChatFindDetailResponse> responses = chatWithAuthors.stream()
 			.map(ChatFindDetailResponse::toResponse)
 			.toList();
-		return new ChatFindUnloadedResponse(responses);
+		return new OldChatFindUnloadedResponse(responses);
 	}
 }

--- a/backend/src/main/java/mouda/backend/moim/presentation/response/chat/OldChatPreviewResponses.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/response/chat/OldChatPreviewResponses.java
@@ -4,13 +4,13 @@ import java.util.List;
 
 import mouda.backend.moim.domain.MoimChat;
 
-public record ChatPreviewResponses(
+public record OldChatPreviewResponses(
 	List<ChatPreviewResponse> chatPreviewResponses
 ) {
-	public static ChatPreviewResponses toResponse(List<MoimChat> moimChats) {
+	public static OldChatPreviewResponses toResponse(List<MoimChat> moimChats) {
 		List<ChatPreviewResponse> chatPreviews = moimChats.stream()
 			.map(ChatPreviewResponse::toResponse)
 			.toList();
-		return new ChatPreviewResponses(chatPreviews);
+		return new OldChatPreviewResponses(chatPreviews);
 	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
구버전 Chat 기능과 신버전 Chat 기능 호환성 문제 해결 & 배팅 디테일 조회 실패 문제 해결

## 이슈 ID는 무엇인가요?

- #617 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->
- 기존 채팅 관련 API 스펙과 새로 구현한 채팅 API 스펙이 달라지며 생기는 버그들을 수정합니다. 
    - ChatPreviewResponse의 targetId -> chatRoomId 변경
    - 기존 요청,응답 를 새로 생성한 요청,응답객체와 호환하는 작업 코드 추가

- 배팅 디테일 정보 조회 시 NON_MOIMEE가 아닌 NON_PARTICIPANT 를 반환하는 문제 수정 

## 질문 혹은 공유 사항 (Optional)
새로 구현한 chat API의 스웨거는 `OverridingMethodMustNotAlterParameterConstraints` 버그로 인해 임시로 적용을 해제했습니다. 기존 API를 삭제하며 추가할 예정입니다. 
<!-- 필요 시 작성해 주세요. -->
