### PR TITLE
애플 서버로부터 사용자 정보를 받는 기능 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -4,27 +4,29 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import mouda.backend.auth.business.result.LoginProcessResult;
-import mouda.backend.auth.implement.AppleOauthManager;
 import mouda.backend.auth.implement.LoginManager;
 import mouda.backend.auth.presentation.request.AppleOauthRequest;
 import mouda.backend.auth.presentation.response.LoginResponse;
+import mouda.backend.member.domain.Member;
 import mouda.backend.member.domain.OauthType;
+import mouda.backend.member.implement.MemberFinder;
 
 @Service
 @RequiredArgsConstructor
 public class AppleAuthService {
 
-	private final AppleOauthManager oauthManager;
 	private final LoginManager loginManager;
+	private final MemberFinder memberFinder;
 
 	public LoginResponse oauthLogin(AppleOauthRequest oauthRequest) {
-		String socialLoginId = oauthManager.getSocialLoginId(oauthRequest.code());
+		Member member = memberFinder.findByNonce(oauthRequest.nonce());
+		// TODO: 사용자 전환 로직 실행 이전부터 애플 소셜 회원가입이 진행되어있음. 현재 카카오 사용자가 전환을 시도하여 애플 로그인하면 같은 애플 로그인 사용자가 두 명이 되면서 에러가 터질 것.
 		if (oauthRequest.memberId() != null) {
-			String accessToken = loginManager.updateOauth(oauthRequest.memberId(), OauthType.APPLE, socialLoginId);
+			String accessToken = loginManager.updateOauth(oauthRequest.memberId(), OauthType.APPLE,
+				member.getSocialLoginId(), oauthRequest.nonce());
 			return new LoginResponse(accessToken);
 		}
-		LoginProcessResult loginProcessResult = loginManager.processSocialLogin(
-			OauthType.APPLE, socialLoginId, oauthRequest.name());
-		return new LoginResponse(loginProcessResult.accessToken());
+		LoginProcessResult result = loginManager.processAppleLogin(member);
+		return new LoginResponse(result.accessToken());
 	}
 }

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -3,6 +3,7 @@ package mouda.backend.auth.business;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import mouda.backend.auth.business.result.LoginProcessResult;
 import mouda.backend.auth.implement.LoginManager;
 import mouda.backend.auth.presentation.request.AppleOauthRequest;
@@ -11,6 +12,7 @@ import mouda.backend.member.domain.Member;
 import mouda.backend.member.domain.OauthType;
 import mouda.backend.member.implement.MemberFinder;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleAuthService {
@@ -28,5 +30,9 @@ public class AppleAuthService {
 		}
 		LoginProcessResult result = loginManager.processAppleLogin(member);
 		return new LoginResponse(result.accessToken());
+	}
+
+	public void save(String idToken, String firstName, String lastName) {
+		log.info("idToken: {}, firstName: {}, lastName: {}", idToken, firstName, lastName);
 	}
 }

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -25,7 +25,7 @@ public class AppleAuthService {
 		// TODO: 사용자 전환 로직 실행 이전부터 애플 소셜 회원가입이 진행되어있음. 현재 카카오 사용자가 전환을 시도하여 애플 로그인하면 같은 애플 로그인 사용자가 두 명이 되면서 에러가 터질 것.
 		if (oauthRequest.memberId() != null) {
 			String accessToken = loginManager.updateOauth(oauthRequest.memberId(), OauthType.APPLE,
-				member.getSocialLoginId(), oauthRequest.nonce());
+				member.getSocialLoginId());
 			return new LoginResponse(accessToken);
 		}
 		LoginProcessResult result = loginManager.processAppleLogin(member);

--- a/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
@@ -50,7 +50,11 @@ public class LoginManager {
 		return new LoginProcessResult(newMember.getId(), accessTokenProvider.provide(newMember));
 	}
 
-	public String updateOauth(long memberId, OauthType oauthType, String socialLoginId) {
+	public LoginProcessResult processAppleLogin(Member member) {
+		return new LoginProcessResult(member.getId(), accessTokenProvider.provide(member));
+	}
+
+	public String updateOauth(long memberId, OauthType oauthType, String socialLoginId, String nonce) {
 		Member member = memberFinder.findBySocialId(socialLoginId);
 		memberWriter.updateLoginDetail(memberId, oauthType, socialLoginId);
 

--- a/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
@@ -54,7 +54,7 @@ public class LoginManager {
 		return new LoginProcessResult(member.getId(), accessTokenProvider.provide(member));
 	}
 
-	public String updateOauth(long memberId, OauthType oauthType, String socialLoginId, String nonce) {
+	public String updateOauth(long memberId, OauthType oauthType, String socialLoginId) {
 		Member member = memberFinder.findBySocialId(socialLoginId);
 		memberWriter.updateLoginDetail(memberId, oauthType, socialLoginId);
 

--- a/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
@@ -1,0 +1,24 @@
+package mouda.backend.auth.presentation.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import mouda.backend.auth.business.AppleAuthService;
+
+@RestController
+public class AppleAuthController {
+
+	private AppleAuthService appleAuthService;
+
+	@PostMapping("/oauth/apple")
+	public void test(@RequestBody JsonNode jsonNode) {
+		String idToken = jsonNode.get("authorization").get("id_token").asText();
+		String firstName = jsonNode.get("user").get("name").get("firstName").asText();
+		String lastName = jsonNode.get("user").get("name").get("lastName").asText();
+
+		appleAuthService.save(idToken, firstName, lastName);
+	}
+}

--- a/backend/src/main/java/mouda/backend/auth/presentation/request/AppleOauthRequest.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/request/AppleOauthRequest.java
@@ -1,14 +1,7 @@
 package mouda.backend.auth.presentation.request;
 
-import jakarta.validation.constraints.NotNull;
-
 public record AppleOauthRequest(
 	Long memberId,
-
-	@NotNull
-	String code,
-
-	@NotNull
-	String name
+	String nonce
 ) {
 }

--- a/backend/src/main/java/mouda/backend/member/domain/LoginDetail.java
+++ b/backend/src/main/java/mouda/backend/member/domain/LoginDetail.java
@@ -16,12 +16,20 @@ public class LoginDetail {
 
 	private String socialLoginId;
 
+	private String nonce;
+
 	protected LoginDetail() {
 	}
 
 	public LoginDetail(OauthType oauthType, String socialLoginId) {
 		this.oauthType = oauthType;
 		this.socialLoginId = socialLoginId;
+	}
+
+	public LoginDetail(OauthType oauthType, String socialLoginId, String nonce) {
+		this.oauthType = oauthType;
+		this.socialLoginId = socialLoginId;
+		this.nonce = nonce;
 	}
 
 	@Override

--- a/backend/src/main/java/mouda/backend/member/implement/MemberFinder.java
+++ b/backend/src/main/java/mouda/backend/member/implement/MemberFinder.java
@@ -24,4 +24,9 @@ public class MemberFinder {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new AuthException(HttpStatus.NOT_FOUND, AuthErrorMessage.MEMBER_NOT_FOUND));
 	}
+
+	public Member findByNonce(String nonce) {
+		return memberRepository.findByLoginDetail_Nonce(nonce)
+			.orElseThrow(() -> new AuthException(HttpStatus.NOT_FOUND, AuthErrorMessage.MEMBER_NOT_FOUND));
+	}
 }

--- a/backend/src/main/java/mouda/backend/member/infrastructure/MemberRepository.java
+++ b/backend/src/main/java/mouda/backend/member/infrastructure/MemberRepository.java
@@ -15,6 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByLoginDetail_SocialLoginId(String socialLoginId);
 
+	Optional<Member> findByLoginDetail_Nonce(String nonce);
+
 	@Query("""
 		UPDATE Member m
 		SET m.loginDetail.oauthType = :oauthType, m.loginDetail.socialLoginId = :socialLoginId 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ oauth:
     client-secret: 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
     redirect-uri: https://dev.mouda.site/oauth/google
   apple:
-    redirect-uri: https://dev.mouda.site/oauth/apple
+    redirect-uri: https://api.dev.mouda.site/oauth/apple
 
 aws:
   region:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -27,7 +27,7 @@ oauth:
     client-secret: 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
     redirect-uri: http://localhost:8081/oauth/google
   apple:
-    redirect-uri: https://dev.mouda.site/oauth/apple
+    redirect-uri: https://api.dev.mouda.site/oauth/apple
 
 aws:
   region:

--- a/backend/src/test/java/mouda/backend/auth/business/AppleAuthServiceTest.java
+++ b/backend/src/test/java/mouda/backend/auth/business/AppleAuthServiceTest.java
@@ -1,9 +1,6 @@
 package mouda.backend.auth.business;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -15,10 +12,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import mouda.backend.auth.implement.AppleOauthManager;
 import mouda.backend.auth.presentation.request.AppleOauthRequest;
 import mouda.backend.auth.presentation.response.LoginResponse;
-import mouda.backend.common.fixture.MemberFixture;
-import mouda.backend.member.domain.LoginDetail;
-import mouda.backend.member.domain.Member;
-import mouda.backend.member.domain.OauthType;
 import mouda.backend.member.implement.MemberFinder;
 import mouda.backend.member.infrastructure.MemberRepository;
 
@@ -42,13 +35,14 @@ class AppleAuthServiceTest {
 	@Disabled("실제 Resource Server에게 요청을 보내는 테스트이다. 프론트 서버를 켜서 코드르 발급 받아 필요할 때만 테스트한다.")
 	void oauthLogin() {
 		String code = "";
-		AppleOauthRequest oauthRequest = new AppleOauthRequest(1L, code, "anna");
+		AppleOauthRequest oauthRequest = new AppleOauthRequest(1L, "nonce");
 
 		LoginResponse loginResponse = appleAuthService.oauthLogin(oauthRequest);
 
 		assertThat(loginResponse).isNotNull();
 	}
 
+	/*
 	@DisplayName("사용자 전환을 시도하면 새로운 회원을 추가하지 않고 기존 회원의 정보를 수정한다.")
 	@Test
 	void oauthLoginConvertingMember() {
@@ -58,7 +52,7 @@ class AppleAuthServiceTest {
 		when(memberFinder.findBySocialId(anyString())).thenReturn(anna);
 		Long kakaoMemberId = anna.getId();
 		LoginResponse loginResponse = appleAuthService.oauthLogin(
-			new AppleOauthRequest(kakaoMemberId, "code", anna.getName()));
+			new AppleOauthRequest(kakaoMemberId, "nonce"));
 
 		assertThat(loginResponse).isNotNull();
 		Optional<Member> memberOptional = memberRepository.findById(kakaoMemberId);
@@ -66,5 +60,5 @@ class AppleAuthServiceTest {
 
 		LoginDetail expected = new LoginDetail(OauthType.APPLE, appleSocialLoginId);
 		assertThat(memberOptional.get().getLoginDetail()).isEqualTo(expected);
-	}
+	}*/
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

- 애플 서버로부터 사용자 정보를 받는 기능 구현
- 인증 방식 변경에 다른 nonce 추가

## 이슈 ID는 무엇인가요?

- #630 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

브라우저에서 인가코드를 받아오는 동시에 사용자 이름을 받을 수 있다. 이를 위해 response mode를 form_post로 변경하면 기존 브라우저 리디렉션 방식과 다르게 HTTP POST 요청을 보내어 사용자 정보를 전송한다.

따라서 nonce 필드를 사용해서 브라우저가 서버에게 요청을 보내어 로그인 인증을 시도한다.
서버는 애플 서버의 POST 요청을 받을 Redirect URI로 API를 열어 사용자 정보를 전달 받는다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
