### PR TITLE
Chat 엔티티와 도메인 분리

### DIFF
--- a/backend/src/main/java/mouda/backend/chat/domain/Chat.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chat.java
@@ -1,0 +1,35 @@
+package mouda.backend.chat.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import mouda.backend.chat.entity.ChatType;
+import mouda.backend.darakbangmember.domain.DarakbangMember;
+
+@Getter
+public class Chat {
+
+	private final long id;
+	private final String content;
+	private final DarakbangMember darakbangMember;
+	private final LocalDate date;
+	private final LocalTime time;
+	private final ChatType chatType;
+
+	@Builder
+	public Chat(long id, String content, DarakbangMember darakbangMember, LocalDate date, LocalTime time,
+		ChatType chatType) {
+		this.id = id;
+		this.content = content;
+		this.darakbangMember = darakbangMember;
+		this.date = date;
+		this.time = time;
+		this.chatType = chatType;
+	}
+
+	public boolean isMyMessage(long darakbangMemberId) {
+		return darakbangMember.getId() == darakbangMemberId;
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
@@ -1,15 +1,14 @@
 package mouda.backend.chat.domain;
 
 import lombok.Getter;
-import mouda.backend.chat.entity.ChatEntity;
 
 @Getter
 public class ChatWithAuthor {
 
-	private final ChatEntity chat;
+	private final Chat chat;
 	private final boolean isMine;
 
-	public ChatWithAuthor(ChatEntity chat, boolean isMine) {
+	public ChatWithAuthor(Chat chat, boolean isMine) {
 		this.chat = chat;
 		this.isMine = isMine;
 	}

--- a/backend/src/main/java/mouda/backend/chat/domain/Chats.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chats.java
@@ -3,15 +3,14 @@ package mouda.backend.chat.domain;
 import java.util.List;
 
 import lombok.Getter;
-import mouda.backend.chat.entity.ChatEntity;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Getter
 public class Chats {
 
-	private final List<ChatEntity> chats;
+	private final List<Chat> chats;
 
-	public Chats(List<ChatEntity> chats) {
+	public Chats(List<Chat> chats) {
 		this.chats = chats;
 	}
 

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
@@ -60,10 +60,6 @@ public class ChatEntity {
 			.build();
 	}
 
-	public boolean isMyMessage(Long darakbangMemberId) {
-		return darakbangMemberId == darakbangMember.getId();
-	}
-
 	public LocalDateTime getDateTime() {
 		if (date == null || time == null) {
 			return null;

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.chat.domain.Chat;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 import mouda.backend.moim.domain.ChatType;
 
@@ -69,5 +70,16 @@ public class ChatEntity {
 			return null;
 		}
 		return LocalDateTime.of(date, time);
+	}
+
+	public Chat toChat() {
+		return Chat.builder()
+			.id(id)
+			.darakbangMember(darakbangMember)
+			.content(content)
+			.chatType(chatType)
+			.date(date)
+			.time(time)
+			.build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
@@ -18,7 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mouda.backend.chat.domain.Chat;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.domain.ChatType;
 
 @Entity
 @Getter

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatType.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatType.java
@@ -1,0 +1,6 @@
+package mouda.backend.chat.entity;
+
+public enum ChatType {
+
+	BASIC, PLACE, DATETIME
+}

--- a/backend/src/main/java/mouda/backend/chat/implement/ChatRoomFinder.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/ChatRoomFinder.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import mouda.backend.bet.infrastructure.BetDarakbangMemberRepository;
+import mouda.backend.chat.domain.Chat;
 import mouda.backend.chat.domain.ChatRoom;
 import mouda.backend.chat.domain.ChatRoomType;
 import mouda.backend.chat.domain.Chats;
@@ -74,7 +75,9 @@ public class ChatRoomFinder {
 	}
 
 	public Chats findAllUnloadedChats(long chatRoomId, long recentChatId) {
-		List<ChatEntity> chats = chatRepository.findAllUnloadedChats(chatRoomId, recentChatId);
+		List<Chat> chats = chatRepository.findAllUnloadedChats(chatRoomId, recentChatId).stream()
+			.map(ChatEntity::toChat)
+			.toList();
 		return new Chats(chats);
 	}
 

--- a/backend/src/main/java/mouda/backend/chat/implement/ChatWriter.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/ChatWriter.java
@@ -10,9 +10,9 @@ import mouda.backend.bet.implement.BetDarakbangMemberWriter;
 import mouda.backend.chat.domain.ChatRoom;
 import mouda.backend.chat.domain.ChatRoomType;
 import mouda.backend.chat.entity.ChatEntity;
+import mouda.backend.chat.entity.ChatType;
 import mouda.backend.chat.infrastructure.ChatRepository;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.domain.ChatType;
 import mouda.backend.moim.implement.writer.ChamyoWriter;
 
 @Component

--- a/backend/src/main/java/mouda/backend/chat/presentation/request/DateTimeConfirmRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/request/DateTimeConfirmRequest.java
@@ -5,8 +5,8 @@ import java.time.LocalTime;
 
 import jakarta.validation.constraints.NotNull;
 import mouda.backend.chat.entity.ChatEntity;
+import mouda.backend.chat.entity.ChatType;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.domain.ChatType;
 
 public record DateTimeConfirmRequest(
 	@NotNull

--- a/backend/src/main/java/mouda/backend/chat/presentation/request/PlaceConfirmRequest.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/request/PlaceConfirmRequest.java
@@ -5,8 +5,8 @@ import java.time.LocalTime;
 
 import jakarta.validation.constraints.NotBlank;
 import mouda.backend.chat.entity.ChatEntity;
+import mouda.backend.chat.entity.ChatType;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.domain.ChatType;
 
 public record PlaceConfirmRequest(
 	@NotBlank

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import lombok.Builder;
+import mouda.backend.chat.domain.Chat;
 import mouda.backend.chat.domain.ChatWithAuthor;
-import mouda.backend.chat.entity.ChatEntity;
-import mouda.backend.moim.domain.ChatType;
+import mouda.backend.chat.entity.ChatType;
 
 @Builder
 public record ChatFindDetailResponse(
@@ -19,7 +19,7 @@ public record ChatFindDetailResponse(
 	ChatType chatType
 ) {
 	public static ChatFindDetailResponse toResponse(ChatWithAuthor chatWithAuthor) {
-		ChatEntity chat = chatWithAuthor.getChat();
+		Chat chat = chatWithAuthor.getChat();
 		return ChatFindDetailResponse.builder()
 			.chatId(chat.getId())
 			.content(chat.getContent())

--- a/backend/src/test/java/mouda/backend/chat/business/ChatRoomServiceTest.java
+++ b/backend/src/test/java/mouda/backend/chat/business/ChatRoomServiceTest.java
@@ -18,6 +18,7 @@ import mouda.backend.bet.infrastructure.BetRepository;
 import mouda.backend.chat.domain.ChatRoomType;
 import mouda.backend.chat.entity.ChatEntity;
 import mouda.backend.chat.entity.ChatRoomEntity;
+import mouda.backend.chat.entity.ChatType;
 import mouda.backend.chat.infrastructure.ChatRepository;
 import mouda.backend.chat.infrastructure.ChatRoomRepository;
 import mouda.backend.chat.presentation.request.ChatCreateRequest;
@@ -28,7 +29,6 @@ import mouda.backend.common.fixture.ChatRoomEntityFixture;
 import mouda.backend.common.fixture.DarakbangSetUp;
 import mouda.backend.common.fixture.MoimFixture;
 import mouda.backend.moim.domain.Chamyo;
-import mouda.backend.moim.domain.ChatType;
 import mouda.backend.moim.domain.Moim;
 import mouda.backend.moim.domain.MoimRole;
 import mouda.backend.moim.infrastructure.ChamyoRepository;
@@ -153,7 +153,8 @@ public class ChatRoomServiceTest extends DarakbangSetUp {
 		chatService.createChat(darakbang.getId(), 1L, new ChatCreateRequest("1번 채팅"), darakbangAnna);
 		chatService.createChat(darakbang.getId(), 2L, new ChatCreateRequest("2번 채팅"), darakbangAnna);
 
-		List<ChatPreviewResponse> chatPreviewResponses = chatRoomService.findChatPreview(darakbangAnna, ChatRoomType.MOIM)
+		List<ChatPreviewResponse> chatPreviewResponses = chatRoomService.findChatPreview(darakbangAnna,
+				ChatRoomType.MOIM)
 			.previews();
 
 		assertThat(chatPreviewResponses).extracting(ChatPreviewResponse::lastContent)

--- a/backend/src/test/java/mouda/backend/common/fixture/ChatEntityFixture.java
+++ b/backend/src/test/java/mouda/backend/common/fixture/ChatEntityFixture.java
@@ -4,8 +4,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import mouda.backend.chat.entity.ChatEntity;
+import mouda.backend.chat.entity.ChatType;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
-import mouda.backend.moim.domain.ChatType;
 
 public class ChatEntityFixture {
 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

도메인과 DTO가 ChatEntity를 의존하지 않도록 변경했습니다.


## 이슈 ID는 무엇인가요?

- close #637 

## 설명

- 도메인과 엔티티의 의존 방향을 변경하고 DTO가 엔티티에 의존하지 않도록 변경했습니다.
- ChatEntity가 moim 패키지의 ChatType을 의존하지 않도록 chat 패키지에 ChatType을 추가했습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
