### PR TITLE
프로필 사진 변경시 기존 이미지가 있다면 s3에서 삭제한다.

### DIFF
--- a/backend/src/main/java/mouda/backend/darakbangmember/business/DarakbangMemberService.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/business/DarakbangMemberService.java
@@ -65,6 +65,9 @@ public class DarakbangMemberService {
 		if (file != null) { // 새로 추가된 파일이 있는 경우
 			String url = s3Client.uploadFile(file); // S3 Upload
 			String newProfileUrl = imageParser.parse(url); // 새로 저장할 profile url
+			if (darakbangMember.hasImage()) { // 기존 이미지가 있다면 s3에서 삭제
+				s3Client.deleteFile(darakbangMember.getProfile());
+			}
 			darakbangMemberWriter.updateMyInfo(darakbangMember, nickname, description, newProfileUrl);
 			return;
 		}

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -107,6 +107,10 @@ public class DarakbangMember {
 		return !isSameMemberWith(other);
 	}
 
+	public boolean hasImage() {
+		return profile != null;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)

--- a/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/exception/DarakbangMemberErrorMessage.java
@@ -13,6 +13,7 @@ public enum DarakbangMemberErrorMessage {
 	MEMBER_ALREADY_EXIST("이미 가입한 멤버입니다."),
 	MEMBER_NOT_EXIST("존재하지 않는 다락방 멤버입니다."),
 	NOT_ALLOWED_TO_READ("조회 권한이 없습니다."),
+	INVALID_DELETE_FILE("기존 이미지를 삭제할 수 없습니다."),
 	INVALID_FILE("잘못된 이미지 파일입니다.");
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/darakbangmember/implement/S3Client.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/implement/S3Client.java
@@ -42,4 +42,12 @@ public class S3Client {
 			throw new DarakbangMemberException(HttpStatus.BAD_REQUEST, DarakbangMemberErrorMessage.INVALID_FILE);
 		}
 	}
+
+	public void deleteFile(String fileUrl) {
+		try {
+			amazonS3.deleteObject(bucket, fileUrl);
+		} catch (Exception e) {
+			throw new DarakbangMemberException(HttpStatus.BAD_REQUEST, DarakbangMemberErrorMessage.INVALID_DELETE_FILE);
+		}
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

프로필 사진 변경시 기존 이미지가 있다면 s3에서 삭제한다.

## 이슈 ID는 무엇인가요?

- #645 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

만약 기존 프로필 사진이 있는 상태에서 사진을 변경한다면 기존 이미지는 s3에서 삭제해야 한다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
