### PR TITLE
chat 작성자 이름 오류 및 chatroom 조회 오류 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/domain/Bet.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/Bet.java
@@ -3,12 +3,8 @@ package mouda.backend.bet.domain;
 import java.util.List;
 import java.util.Random;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Builder;
 import lombok.Getter;
-import mouda.backend.bet.exception.BetErrorMessage;
-import mouda.backend.bet.exception.BetException;
 
 @Getter
 public class Bet {
@@ -53,13 +49,6 @@ public class Bet {
 			.anyMatch(participant -> participant.getId() == id);
 	}
 
-	public long getLoserId() {
-		if (loserId == null) {
-			throw new BetException(HttpStatus.NOT_FOUND, BetErrorMessage.LOSER_NOT_FOUND);
-		}
-		return loserId;
-	}
-
 	public boolean isLoser(long otherId) {
 		return loserId == otherId;
 	}
@@ -74,5 +63,9 @@ public class Bet {
 
 	public long timeDifferenceInMinutesWithNow() {
 		return betDetails.timeDifferenceInMinutesWithNow();
+	}
+
+	public boolean canNotParticipant() {
+		return hasLoser() || betDetails.pastBettingTime();
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/domain/Bet.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/Bet.java
@@ -65,7 +65,7 @@ public class Bet {
 		return betDetails.timeDifferenceInMinutesWithNow();
 	}
 
-	public boolean canNotParticipant() {
+	public boolean canNotParticipate() {
 		return hasLoser() || betDetails.pastBettingTime();
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
@@ -8,31 +8,37 @@ import lombok.Getter;
 @Getter
 public class BetDetails {
 
-    private final Long id;
-    private final String title;
-    private final BettingTime bettingTime;
+	private final Long id;
+	private final String title;
+	private final BettingTime bettingTime;
+	private final Long loserId;
 
-    @Builder
-    public BetDetails(Long id, String title, LocalDateTime bettingTime) {
-        this.id = id;
-        this.title = title;
-        this.bettingTime = new BettingTime(bettingTime);
-    }
+	@Builder
+	public BetDetails(Long id, String title, LocalDateTime bettingTime, Long loserId) {
+		this.id = id;
+		this.title = title;
+		this.bettingTime = new BettingTime(bettingTime);
+		this.loserId = loserId;
+	}
 
-    public static BetDetails create(String title, int waitingMinutes) {
-        LocalDateTime bettingTime = LocalDateTime.now().plusMinutes(waitingMinutes);
+	public static BetDetails create(String title, int waitingMinutes) {
+		LocalDateTime bettingTime = LocalDateTime.now().plusMinutes(waitingMinutes);
 
-        return BetDetails.builder()
-            .title(title)
-            .bettingTime(bettingTime)
-            .build();
-    }
+		return BetDetails.builder()
+			.title(title)
+			.bettingTime(bettingTime)
+			.build();
+	}
 
-    public LocalDateTime getBettingTime() {
-        return bettingTime.getBettingTime();
-    }
+	public LocalDateTime getBettingTime() {
+		return bettingTime.getBettingTime();
+	}
 
-    public long timeDifferenceInMinutesWithNow() {
-        return bettingTime.timeDifferenceInMinutesWithNow();
-    }
+	public long timeDifferenceInMinutesWithNow() {
+		return bettingTime.timeDifferenceInMinutesWithNow();
+	}
+
+	public boolean hasLoser() {
+		return loserId != null;
+	}
 }

--- a/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
@@ -43,4 +43,8 @@ public class BetDetails {
 	public boolean hasLoser() {
 		return loserId != null;
 	}
+
+	public boolean pastBettingTime() {
+		return bettingTime.isPast();
+	}
 }

--- a/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
@@ -8,16 +8,18 @@ import lombok.Getter;
 @Getter
 public class BetDetails {
 
-	private final Long id;
+	private final long id;
 	private final String title;
 	private final BettingTime bettingTime;
+	private final long moimerId;
 	private final Long loserId;
 
 	@Builder
-	public BetDetails(Long id, String title, LocalDateTime bettingTime, Long loserId) {
+	public BetDetails(long id, String title, LocalDateTime bettingTime, long moimerId, Long loserId) {
 		this.id = id;
 		this.title = title;
 		this.bettingTime = new BettingTime(bettingTime);
+		this.moimerId = moimerId;
 		this.loserId = loserId;
 	}
 

--- a/backend/src/main/java/mouda/backend/bet/domain/BettingTime.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BettingTime.java
@@ -8,20 +8,24 @@ import lombok.Getter;
 @Getter
 public class BettingTime {
 
-    private static final int NO_SECONDS = 0;
-    private static final int NO_NANOS = 0;
+	private static final int NO_SECONDS = 0;
+	private static final int NO_NANOS = 0;
 
-    private final LocalDateTime bettingTime;
+	private final LocalDateTime bettingTime;
 
-    public BettingTime(LocalDateTime bettingTime) {
-        this.bettingTime = normalize(bettingTime);
-    }
+	public BettingTime(LocalDateTime bettingTime) {
+		this.bettingTime = normalize(bettingTime);
+	}
 
-    private LocalDateTime normalize(LocalDateTime bettingTime) {
-        return bettingTime.withSecond(NO_SECONDS).withNano(NO_NANOS);
-    }
+	private LocalDateTime normalize(LocalDateTime bettingTime) {
+		return bettingTime.withSecond(NO_SECONDS).withNano(NO_NANOS);
+	}
 
-    public long timeDifferenceInMinutesWithNow() {
-        return Math.abs(ChronoUnit.MINUTES.between(normalize(LocalDateTime.now()), this.bettingTime));
-    }
+	public long timeDifferenceInMinutesWithNow() {
+		return Math.abs(ChronoUnit.MINUTES.between(normalize(LocalDateTime.now()), this.bettingTime));
+	}
+
+	public boolean isPast() {
+		return LocalDateTime.now().isAfter(bettingTime);
+	}
 }

--- a/backend/src/main/java/mouda/backend/bet/entity/BetDarakbangMemberEntity.java
+++ b/backend/src/main/java/mouda/backend/bet/entity/BetDarakbangMemberEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mouda.backend.bet.domain.BetRole;
@@ -16,7 +17,14 @@ import mouda.backend.darakbangmember.domain.DarakbangMember;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "bet_darakbang_member")
+@Table(
+	name = "bet_darakbang_member",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			columnNames = {"bet_id", "darakbang_member_id"}
+		)
+	}
+)
 public class BetDarakbangMemberEntity {
 
 	@Id

--- a/backend/src/main/java/mouda/backend/bet/entity/BetDarakbangMemberEntity.java
+++ b/backend/src/main/java/mouda/backend/bet/entity/BetDarakbangMemberEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.bet.domain.BetRole;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Entity
@@ -39,5 +40,12 @@ public class BetDarakbangMemberEntity {
 
 	public void updateLastChat(Long lastReadChatId) {
 		this.lastReadChatId = lastReadChatId;
+	}
+
+	public String getRole(long moimerId) {
+		if (darakbangMember.getId() == moimerId) {
+			return BetRole.MOIMER.name();
+		}
+		return BetRole.MOIMEE.name();
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/entity/BetEntity.java
+++ b/backend/src/main/java/mouda/backend/bet/entity/BetEntity.java
@@ -39,7 +39,8 @@ public class BetEntity {
 	private long moimerId;
 
 	@Builder
-	private BetEntity(Long id, String title, LocalDateTime bettingTime, Long loserDarakbangMemberId, long darakbangId, long moimerId) {
+	private BetEntity(Long id, String title, LocalDateTime bettingTime, Long loserDarakbangMemberId, long darakbangId,
+		long moimerId) {
 		this.id = id;
 		this.title = title;
 		this.bettingTime = bettingTime;
@@ -74,6 +75,7 @@ public class BetEntity {
 			.id(id)
 			.title(title)
 			.bettingTime(bettingTime)
+			.loserId(loserDarakbangMemberId)
 			.build();
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/exception/BetErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/bet/exception/BetErrorMessage.java
@@ -9,7 +9,8 @@ public enum BetErrorMessage {
 
 	BET_DARAKBANG_MEMBER_NOT_FOUND("참여하지 않은 안내면진다입니다."),
 	BET_NOT_FOUND("안내면진다가 존재하지 않습니다."),
-	LOSER_NOT_FOUND("당첨자가 존재하지 않습니다.");
-	
+	LOSER_NOT_FOUND("당첨자가 존재하지 않습니다."),
+	ALREADY_PARTICIPATED_BET("이미 참여한 안내면진다입니다.");
+
 	private final String message;
 }

--- a/backend/src/main/java/mouda/backend/bet/exception/BetErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/bet/exception/BetErrorMessage.java
@@ -10,6 +10,7 @@ public enum BetErrorMessage {
 	BET_DARAKBANG_MEMBER_NOT_FOUND("참여하지 않은 안내면진다입니다."),
 	BET_NOT_FOUND("안내면진다가 존재하지 않습니다."),
 	LOSER_NOT_FOUND("당첨자가 존재하지 않습니다."),
+	CAN_NOT_PARTICIPATE("참여할 수 없는 안내면진다입니다."),
 	ALREADY_PARTICIPATED_BET("이미 참여한 안내면진다입니다.");
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
@@ -39,6 +39,9 @@ public class BetWriter {
 
 	public void participate(long darakbangId, long betId, DarakbangMember darakbangMember) {
 		Bet bet = betFinder.find(darakbangId, betId);
+		if (bet.canNotParticipant()) {
+			throw new BetException(HttpStatus.BAD_REQUEST, BetErrorMessage.CAN_NOT_PARTICIPATE);
+		}
 		participate(darakbangMember, bet);
 	}
 

--- a/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
@@ -39,7 +39,7 @@ public class BetWriter {
 
 	public void participate(long darakbangId, long betId, DarakbangMember darakbangMember) {
 		Bet bet = betFinder.find(darakbangId, betId);
-		if (bet.canNotParticipant()) {
+		if (bet.canNotParticipate()) {
 			throw new BetException(HttpStatus.BAD_REQUEST, BetErrorMessage.CAN_NOT_PARTICIPATE);
 		}
 		participate(darakbangMember, bet);

--- a/backend/src/main/java/mouda/backend/chat/business/ChatService.java
+++ b/backend/src/main/java/mouda/backend/chat/business/ChatService.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import mouda.backend.chat.domain.ChatOwnership;
 import mouda.backend.chat.domain.ChatRoom;
-import mouda.backend.chat.domain.ChatWithAuthor;
 import mouda.backend.chat.domain.Chats;
 import mouda.backend.chat.implement.ChatRoomFinder;
 import mouda.backend.chat.implement.ChatWriter;
@@ -59,7 +59,7 @@ public class ChatService {
 		ChatRoom chatRoom = chatRoomFinder.read(darakbangId, chatRoomId, darakbangMember);
 
 		Chats chats = chatRoomFinder.findAllUnloadedChats(chatRoom.getId(), recentChatId);
-		List<ChatWithAuthor> chatsWithAuthor = chats.getChatsWithAuthor(darakbangMember);
+		List<ChatOwnership> chatsWithAuthor = chats.getChatsWithAuthor(darakbangMember);
 
 		return ChatFindUnloadedResponse.toResponse(chatsWithAuthor);
 	}

--- a/backend/src/main/java/mouda/backend/chat/domain/Author.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Author.java
@@ -1,0 +1,19 @@
+package mouda.backend.chat.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Author {
+
+	private final long id;
+	private final String nickname;
+	private final String profile;
+
+	@Builder
+	public Author(long id, String nickname, String profile) {
+		this.id = id;
+		this.nickname = nickname;
+		this.profile = profile;
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/domain/Chat.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chat.java
@@ -27,7 +27,7 @@ public class Chat {
 		this.chatType = chatType;
 	}
 
-	public boolean isMyMessage(long darakbangMemberId) {
+	public boolean isMine(long darakbangMemberId) {
 		return author.getId() == darakbangMemberId;
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Chat.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chat.java
@@ -6,30 +6,28 @@ import java.time.LocalTime;
 import lombok.Builder;
 import lombok.Getter;
 import mouda.backend.chat.entity.ChatType;
-import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Getter
 public class Chat {
 
 	private final long id;
 	private final String content;
-	private final DarakbangMember darakbangMember;
+	private final Author author;
 	private final LocalDate date;
 	private final LocalTime time;
 	private final ChatType chatType;
 
 	@Builder
-	public Chat(long id, String content, DarakbangMember darakbangMember, LocalDate date, LocalTime time,
-		ChatType chatType) {
+	public Chat(long id, String content, Author author, LocalDate date, LocalTime time, ChatType chatType) {
 		this.id = id;
 		this.content = content;
-		this.darakbangMember = darakbangMember;
+		this.author = author;
 		this.date = date;
 		this.time = time;
 		this.chatType = chatType;
 	}
 
 	public boolean isMyMessage(long darakbangMemberId) {
-		return darakbangMember.getId() == darakbangMemberId;
+		return author.getId() == darakbangMemberId;
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/ChatOwnership.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/ChatOwnership.java
@@ -3,12 +3,12 @@ package mouda.backend.chat.domain;
 import lombok.Getter;
 
 @Getter
-public class ChatWithAuthor {
+public class ChatOwnership {
 
 	private final Chat chat;
 	private final boolean isMine;
 
-	public ChatWithAuthor(Chat chat, boolean isMine) {
+	public ChatOwnership(Chat chat, boolean isMine) {
 		this.chat = chat;
 		this.isMine = isMine;
 	}

--- a/backend/src/main/java/mouda/backend/chat/domain/ChatRoom.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/ChatRoom.java
@@ -3,29 +3,24 @@ package mouda.backend.chat.domain;
 import java.time.LocalDateTime;
 
 import lombok.Getter;
-import mouda.backend.chat.entity.ChatEntity;
-import mouda.backend.chat.entity.ChatRoomEntity;
 
 @Getter
 public class ChatRoom {
 
-	private final Long id;
+	private final long id;
 	private final long targetId;
 	private final ChatRoomType type;
 	private final LastChat lastChat;
 
-	public ChatRoom(ChatRoomEntity chatRoomEntity, ChatEntity lastChat) {
-		this.id = chatRoomEntity.getId();
-		this.targetId = chatRoomEntity.getTargetId();
-		this.type = chatRoomEntity.getType();
-		this.lastChat = new LastChat(lastChat.getDateTime(), lastChat.getContent());
+	public ChatRoom(Long id, long targetId, ChatRoomType type, LastChat lastChat) {
+		this.id = id;
+		this.targetId = targetId;
+		this.type = type;
+		this.lastChat = lastChat;
 	}
 
-	public ChatRoom(ChatRoomEntity chatRoomEntity) {
-		this.id = chatRoomEntity.getId();
-		this.targetId = chatRoomEntity.getTargetId();
-		this.type = chatRoomEntity.getType();
-		this.lastChat = LastChat.empty();
+	public ChatRoom(Long id, long targetId, ChatRoomType type) {
+		this(id, targetId, type, LastChat.empty());
 	}
 
 	public boolean isMoim() {

--- a/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
@@ -6,12 +6,10 @@ import lombok.Getter;
 public class ChatWithAuthor {
 
 	private final Chat chat;
-	private final Participant participant;
 	private final boolean isMine;
 
 	public ChatWithAuthor(Chat chat, boolean isMine) {
 		this.chat = chat;
-		this.participant = new Participant(chat);
 		this.isMine = isMine;
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/ChatWithAuthor.java
@@ -9,9 +9,9 @@ public class ChatWithAuthor {
 	private final Participant participant;
 	private final boolean isMine;
 
-	public ChatWithAuthor(Chat chat, Participant participant,boolean isMine) {
+	public ChatWithAuthor(Chat chat, boolean isMine) {
 		this.chat = chat;
-		this.participant = participant;
+		this.participant = new Participant(chat);
 		this.isMine = isMine;
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Chats.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chats.java
@@ -16,11 +16,7 @@ public class Chats {
 
 	public List<ChatWithAuthor> getChatsWithAuthor(DarakbangMember darakbangMember) {
 		return chats.stream()
-			.map(chat -> new ChatWithAuthor(chat, new Participant(
-				darakbangMember.getNickname(),
-				darakbangMember.getProfile(),
-				darakbangMember.getDescription()),
-				chat.isMyMessage(darakbangMember.getId())))
+			.map(chat -> new ChatWithAuthor(chat, chat.isMyMessage(darakbangMember.getId())))
 			.toList();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Chats.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chats.java
@@ -14,9 +14,9 @@ public class Chats {
 		this.chats = chats;
 	}
 
-	public List<ChatWithAuthor> getChatsWithAuthor(DarakbangMember darakbangMember) {
+	public List<ChatOwnership> getChatsWithAuthor(DarakbangMember darakbangMember) {
 		return chats.stream()
-			.map(chat -> new ChatWithAuthor(chat, chat.isMine(darakbangMember.getId())))
+			.map(chat -> new ChatOwnership(chat, chat.isMine(darakbangMember.getId())))
 			.toList();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Chats.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Chats.java
@@ -16,7 +16,7 @@ public class Chats {
 
 	public List<ChatWithAuthor> getChatsWithAuthor(DarakbangMember darakbangMember) {
 		return chats.stream()
-			.map(chat -> new ChatWithAuthor(chat, chat.isMyMessage(darakbangMember.getId())))
+			.map(chat -> new ChatWithAuthor(chat, chat.isMine(darakbangMember.getId())))
 			.toList();
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/domain/Participant.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Participant.java
@@ -17,12 +17,6 @@ public class Participant {
 		this.role = role;
 	}
 
-	public Participant(Chat chat) {
-		this.nickname = chat.getDarakbangMember().getNickname();
-		this.profile = chat.getDarakbangMember().getProfile();
-		this.role = chat.getDarakbangMember().getDescription();
-	}
-
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)

--- a/backend/src/main/java/mouda/backend/chat/domain/Participant.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Participant.java
@@ -17,6 +17,12 @@ public class Participant {
 		this.role = role;
 	}
 
+	public Participant(Chat chat) {
+		this.nickname = chat.getDarakbangMember().getNickname();
+		this.profile = chat.getDarakbangMember().getProfile();
+		this.role = chat.getDarakbangMember().getDescription();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)
@@ -24,7 +30,8 @@ public class Participant {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		Participant that = (Participant)o;
-		return Objects.equals(nickname, that.nickname) && Objects.equals(profile, that.profile) && Objects.equals(role, that.role);
+		return Objects.equals(nickname, that.nickname) && Objects.equals(profile, that.profile) && Objects.equals(role,
+			that.role);
 	}
 
 	@Override

--- a/backend/src/main/java/mouda/backend/chat/domain/Target.java
+++ b/backend/src/main/java/mouda/backend/chat/domain/Target.java
@@ -7,7 +7,7 @@ import mouda.backend.moim.domain.Moim;
 @Getter
 public class Target {
 
-	private final Long targetId;
+	private final long targetId;
 	private final String title;
 	private final boolean isStarted;
 

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mouda.backend.chat.domain.Chat;
+import mouda.backend.chat.domain.LastChat;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 
 @Entity
@@ -54,19 +55,6 @@ public class ChatEntity {
 		this.chatType = chatType;
 	}
 
-	public static ChatEntity empty() {
-		return ChatEntity.builder()
-			.content("")
-			.build();
-	}
-
-	public LocalDateTime getDateTime() {
-		if (date == null || time == null) {
-			return null;
-		}
-		return LocalDateTime.of(date, time);
-	}
-
 	public Chat toChat() {
 		return Chat.builder()
 			.id(id)
@@ -76,5 +64,9 @@ public class ChatEntity {
 			.date(date)
 			.time(time)
 			.build();
+	}
+
+	public LastChat toLastChat() {
+		return new LastChat(LocalDateTime.of(date, time), content);
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
+++ b/backend/src/main/java/mouda/backend/chat/entity/ChatEntity.java
@@ -58,7 +58,7 @@ public class ChatEntity {
 	public Chat toChat() {
 		return Chat.builder()
 			.id(id)
-			.darakbangMember(darakbangMember)
+			.author(darakbangMember.toAuthor())
 			.content(content)
 			.chatType(chatType)
 			.date(date)

--- a/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
@@ -43,7 +43,7 @@ public class BetChatPreviewManager implements ChatPreviewManager {
 		List<Participant> participants = betDarakbangMemberRepository.findAllByBetId(targetId).stream()
 			.map(betDarakbangMember -> new Participant(betDarakbangMember.getDarakbangMember().getNickname(),
 				betDarakbangMember.getDarakbangMember().getProfile(),
-				betDarakbangMember.getDarakbangMember().getRole().toString()))
+				betDarakbangMember.getRole(bet.getMoimerId())))
 			.toList();
 
 		return ChatPreview.builder()

--- a/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
@@ -30,6 +30,7 @@ public class BetChatPreviewManager implements ChatPreviewManager {
 		List<BetDetails> myBets = betFinder.readAllMyBets(darakbangMember);
 
 		return myBets.stream()
+			.filter(BetDetails::hasLoser)
 			.map(this::getChatPreview)
 			.sorted()
 			.toList();

--- a/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/BetChatPreviewManager.java
@@ -40,7 +40,8 @@ public class BetChatPreviewManager implements ChatPreviewManager {
 		ChatRoom chatRoom = chatRoomFinder.readChatRoomByTargetId(bet.getId(), ChatRoomType.BET);
 		long lastReadChatId = betDarakbangMemberRepository.findLastReadChatIdByBetId(targetId);
 		List<Participant> participants = betDarakbangMemberRepository.findAllByBetId(targetId).stream()
-			.map(betDarakbangMember -> new Participant(betDarakbangMember.getDarakbangMember().getNickname(), betDarakbangMember.getDarakbangMember().getProfile(),
+			.map(betDarakbangMember -> new Participant(betDarakbangMember.getDarakbangMember().getNickname(),
+				betDarakbangMember.getDarakbangMember().getProfile(),
 				betDarakbangMember.getDarakbangMember().getRole().toString()))
 			.toList();
 

--- a/backend/src/main/java/mouda/backend/chat/implement/ChatRoomFinder.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/ChatRoomFinder.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import mouda.backend.bet.infrastructure.BetDarakbangMemberRepository;
@@ -76,6 +77,7 @@ public class ChatRoomFinder {
 		return new ChatRoom(chatRoomEntity.getId(), chatRoomEntity.getTargetId(), chatRoomEntity.getType(), lastChat);
 	}
 
+	@Transactional(readOnly = true)
 	public Chats findAllUnloadedChats(long chatRoomId, long recentChatId) {
 		List<Chat> chats = chatRepository.findAllUnloadedChats(chatRoomId, recentChatId).stream()
 			.map(ChatEntity::toChat)

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalTime;
 import lombok.Builder;
 import mouda.backend.chat.domain.Author;
 import mouda.backend.chat.domain.Chat;
-import mouda.backend.chat.domain.ChatWithAuthor;
+import mouda.backend.chat.domain.ChatOwnership;
 import mouda.backend.chat.entity.ChatType;
 
 @Builder
@@ -19,21 +19,21 @@ public record ChatFindDetailResponse(
 	LocalTime time,
 	ChatType chatType
 ) {
-	public static ChatFindDetailResponse toResponse(ChatWithAuthor chatWithAuthor) {
-		Chat chat = chatWithAuthor.getChat();
+	public static ChatFindDetailResponse toResponse(ChatOwnership chatOwnership) {
+		Chat chat = chatOwnership.getChat();
 		return ChatFindDetailResponse.builder()
 			.chatId(chat.getId())
 			.content(chat.getContent())
-			.isMyMessage(chatWithAuthor.isMine())
-			.participation(getParticipantResponse(chatWithAuthor))
+			.isMyMessage(chatOwnership.isMine())
+			.participation(getParticipantResponse(chatOwnership))
 			.date(chat.getDate())
 			.time(chat.getTime())
 			.chatType(chat.getChatType())
 			.build();
 	}
 
-	private static ParticipantResponse getParticipantResponse(ChatWithAuthor chatWithAuthor) {
-		Author author = chatWithAuthor.getChat().getAuthor();
+	private static ParticipantResponse getParticipantResponse(ChatOwnership chatOwnership) {
+		Author author = chatOwnership.getChat().getAuthor();
 		return new ParticipantResponse(author.getNickname(), author.getProfile(), null);
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import lombok.Builder;
+import mouda.backend.chat.domain.Author;
 import mouda.backend.chat.domain.Chat;
 import mouda.backend.chat.domain.ChatWithAuthor;
-import mouda.backend.chat.domain.Participant;
 import mouda.backend.chat.entity.ChatType;
 
 @Builder
@@ -33,7 +33,7 @@ public record ChatFindDetailResponse(
 	}
 
 	private static ParticipantResponse getParticipantResponse(ChatWithAuthor chatWithAuthor) {
-		Participant participant = chatWithAuthor.getParticipant();
-		return new ParticipantResponse(participant.getNickname(), participant.getProfile(), participant.getRole());
+		Author author = chatWithAuthor.getChat().getAuthor();
+		return new ParticipantResponse(author.getNickname(), author.getProfile(), null);
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindDetailResponse.java
@@ -34,6 +34,6 @@ public record ChatFindDetailResponse(
 
 	private static ParticipantResponse getParticipantResponse(ChatOwnership chatOwnership) {
 		Author author = chatOwnership.getChat().getAuthor();
-		return new ParticipantResponse(author.getNickname(), author.getProfile(), null);
+		return new ParticipantResponse(author.getNickname(), author.getProfile());
 	}
 }

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindUnloadedResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ChatFindUnloadedResponse.java
@@ -2,12 +2,12 @@ package mouda.backend.chat.presentation.response;
 
 import java.util.List;
 
-import mouda.backend.chat.domain.ChatWithAuthor;
+import mouda.backend.chat.domain.ChatOwnership;
 
 public record ChatFindUnloadedResponse(
 	List<ChatFindDetailResponse> chats
 ) {
-	public static ChatFindUnloadedResponse toResponse(List<ChatWithAuthor> chats) {
+	public static ChatFindUnloadedResponse toResponse(List<ChatOwnership> chats) {
 		List<ChatFindDetailResponse> responses = chats.stream()
 			.map(ChatFindDetailResponse::toResponse)
 			.toList();

--- a/backend/src/main/java/mouda/backend/chat/presentation/response/ParticipantResponse.java
+++ b/backend/src/main/java/mouda/backend/chat/presentation/response/ParticipantResponse.java
@@ -5,4 +5,8 @@ public record ParticipantResponse(
 	String profile,
 	String role
 ) {
+
+	public ParticipantResponse(String nickname, String profile) {
+		this(nickname, profile, null);
+	}
 }

--- a/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
+++ b/backend/src/main/java/mouda/backend/darakbangmember/domain/DarakbangMember.java
@@ -19,6 +19,7 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mouda.backend.chat.domain.Author;
 import mouda.backend.darakbang.domain.Darakbang;
 import mouda.backend.darakbangmember.exception.DarakbangMemberErrorMessage;
 import mouda.backend.darakbangmember.exception.DarakbangMemberException;
@@ -109,6 +110,14 @@ public class DarakbangMember {
 
 	public boolean hasImage() {
 		return profile != null;
+	}
+
+	public Author toAuthor() {
+		return Author.builder()
+			.id(id)
+			.nickname(nickname)
+			.profile(profile)
+			.build();
 	}
 
 	@Override

--- a/backend/src/test/java/mouda/backend/bet/business/BetServiceTest.java
+++ b/backend/src/test/java/mouda/backend/bet/business/BetServiceTest.java
@@ -78,7 +78,7 @@ class BetServiceTest extends DarakbangSetUp {
 	void findNotDrawnBet() {
 		// given
 		long darakbangId = darakbang.getId();
-		BetEntity drawnBetEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity drawnBetEntity = BetEntityFixture.getFutureBetEntity(darakbangId, darakbangAnna.getId());
 		BetEntity savedBetEntity = betRepository.save(drawnBetEntity);
 
 		// when
@@ -138,7 +138,7 @@ class BetServiceTest extends DarakbangSetUp {
 	void drawBet() {
 		// given
 		Long darakbangId = darakbang.getId();
-		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity betEntity = BetEntityFixture.getFutureBetEntity(darakbangId, darakbangAnna.getId());
 		BetEntity savedBetEntity = betRepository.save(betEntity);
 		betWriter.participate(darakbangId, savedBetEntity.getId(), darakbangAnna);
 

--- a/backend/src/test/java/mouda/backend/bet/implement/BetFinderTest.java
+++ b/backend/src/test/java/mouda/backend/bet/implement/BetFinderTest.java
@@ -11,8 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import mouda.backend.bet.domain.Bet;
 import mouda.backend.bet.domain.Loser;
+import mouda.backend.bet.entity.BetDarakbangMemberEntity;
 import mouda.backend.bet.entity.BetEntity;
 import mouda.backend.bet.exception.BetException;
+import mouda.backend.bet.infrastructure.BetDarakbangMemberRepository;
 import mouda.backend.bet.infrastructure.BetRepository;
 import mouda.backend.common.fixture.BetEntityFixture;
 import mouda.backend.common.fixture.DarakbangSetUp;
@@ -27,6 +29,9 @@ class BetFinderTest extends DarakbangSetUp {
 
 	@Autowired
 	BetRepository betRepository;
+
+	@Autowired
+	BetDarakbangMemberRepository betDarakbangMemberRepository;
 
 	@DisplayName("다락방에 존재하는 안내면진다를 조회한다.")
 	@Test
@@ -50,7 +55,7 @@ class BetFinderTest extends DarakbangSetUp {
 	void findAllDetails() {
 		// given
 		long darakbangId = darakbang.getId();
-		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity betEntity = BetEntityFixture.getFutureBetEntity(darakbangId, darakbangAnna.getId());
 		betRepository.save(betEntity);
 
 		// when
@@ -92,7 +97,7 @@ class BetFinderTest extends DarakbangSetUp {
 		long darakbangId = darakbang.getId();
 		BetEntity betEntity = BetEntityFixture.getDrawedBetEntity(darakbangId, darakbangAnna.getId());
 		BetEntity savedBetEntity = betRepository.save(betEntity);
-		betWriter.participate(darakbangId, savedBetEntity.getId(), darakbangAnna);
+		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangAnna, savedBetEntity));
 
 		// when
 		Loser loser = betFinder.findResult(darakbangId, savedBetEntity.getId());

--- a/backend/src/test/java/mouda/backend/bet/implement/BetWriterTest.java
+++ b/backend/src/test/java/mouda/backend/bet/implement/BetWriterTest.java
@@ -2,6 +2,7 @@ package mouda.backend.bet.implement;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,31 @@ class BetWriterTest extends DarakbangSetUp {
 
 	@Autowired
 	BetDarakbangMemberRepository betDarakbangMemberRepository;
+
+	@DisplayName("추첨 시간 이후 참여할 수 없다.")
+	@Test
+	void failToParticipate_pastBettingTIme() {
+		// given
+		LocalDateTime pastBettingTime = LocalDateTime.now().minusSeconds(1);
+		BetEntity bet = betRepository.save(
+			BetEntityFixture.getBetEntity(darakbang.getId(), darakbangAnna.getId(), pastBettingTime));
+
+		// when & then
+		assertThatThrownBy(() -> betService.participateBet(darakbang.getId(), bet.getId(), darakbangHogee))
+			.isInstanceOf(BetException.class);
+	}
+
+	@DisplayName("이미 당첨자가 존재하면 참여할 수 없다.")
+	@Test
+	void failToParticipate_loserExists() {
+		// given
+		BetEntity bet = betRepository.save(
+			BetEntityFixture.getDrawedBetEntity(darakbang.getId(), darakbangAnna.getId()));
+
+		// when & then
+		assertThatThrownBy(() -> betService.participateBet(darakbang.getId(), bet.getId(), darakbangHogee))
+			.isInstanceOf(BetException.class);
+	}
 
 	@DisplayName("중복 참여할 수 없다.")
 	@Test

--- a/backend/src/test/java/mouda/backend/bet/implement/BetWriterTest.java
+++ b/backend/src/test/java/mouda/backend/bet/implement/BetWriterTest.java
@@ -1,0 +1,60 @@
+package mouda.backend.bet.implement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import mouda.backend.bet.business.BetService;
+import mouda.backend.bet.entity.BetDarakbangMemberEntity;
+import mouda.backend.bet.entity.BetEntity;
+import mouda.backend.bet.exception.BetException;
+import mouda.backend.bet.infrastructure.BetDarakbangMemberRepository;
+import mouda.backend.bet.infrastructure.BetRepository;
+import mouda.backend.common.fixture.BetEntityFixture;
+import mouda.backend.common.fixture.DarakbangSetUp;
+
+@SpringBootTest
+class BetWriterTest extends DarakbangSetUp {
+
+	@Autowired
+	BetService betService;
+
+	@Autowired
+	BetRepository betRepository;
+
+	@Autowired
+	BetDarakbangMemberRepository betDarakbangMemberRepository;
+
+	@DisplayName("중복 참여할 수 없다.")
+	@Test
+	void failToParticipate_alreadyParticipate() {
+		// given
+		BetEntity bet = betRepository.save(
+			BetEntityFixture.getFutureBetEntity(darakbang.getId(), darakbangAnna.getId()));
+		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangAnna, bet));
+
+		// when & then
+		assertThatThrownBy(() -> betService.participateBet(darakbang.getId(), bet.getId(), darakbangAnna))
+			.isInstanceOf(BetException.class);
+	}
+
+	@DisplayName("참여에 성공한다.")
+	@Test
+	void participate() {
+		// given
+		BetEntity bet = betRepository.save(
+			BetEntityFixture.getFutureBetEntity(darakbang.getId(), darakbangAnna.getId()));
+
+		// when
+		betService.participateBet(darakbang.getId(), bet.getId(), darakbangHogee);
+
+		// then
+		List<BetDarakbangMemberEntity> participants = betDarakbangMemberRepository.findAllByBetId(bet.getId());
+		assertThat(participants).hasSize(1);
+	}
+}

--- a/backend/src/test/java/mouda/backend/bet/infrastructure/BetRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/bet/infrastructure/BetRepositoryTest.java
@@ -23,14 +23,15 @@ class BetRepositoryTest {
 	@Test
 	void findAllByBettingTimeAndLoserDarakbangMemberIdIsNull() {
 		// given
-		BetEntity betEntity1 = BetEntityFixture.getBetEntity(1L, 1L);
+		BetEntity betEntity1 = BetEntityFixture.getBetEntity(1L, 1L, LocalDateTime.now());
 		BetEntity betEntity2 = BetEntityFixture.getDrawedBetEntity(1L, 2L);
 
 		betRepository.save(betEntity1);
 		betRepository.save(betEntity2);
 
 		// when
-		List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(LocalDateTime.now().withSecond(0).withNano(0));
+		List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(
+			LocalDateTime.now().withSecond(0).withNano(0));
 
 		//then
 		assertThat(betEntities).hasSize(1);

--- a/backend/src/test/java/mouda/backend/chat/business/ChatRoomServiceTest.java
+++ b/backend/src/test/java/mouda/backend/chat/business/ChatRoomServiceTest.java
@@ -92,14 +92,14 @@ public class ChatRoomServiceTest extends DarakbangSetUp {
 	@Test
 	void findBetChatPreview() {
 		// given
-		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbang.getId(), darakbangHogee.getId());
+		BetEntity betEntity = BetEntityFixture.getDrawedBetEntity(darakbang.getId(), darakbangHogee.getId());
 		BetEntity savedBetEntity = betRepository.save(betEntity);
 
 		BetDarakbangMemberEntity betDarakbangMemberEntity = new BetDarakbangMemberEntity(darakbangHogee,
 			savedBetEntity);
 		betDarakbangMemberRepository.save(betDarakbangMemberEntity);
 
-		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity.getId(),
+		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(savedBetEntity.getId(),
 			darakbang.getId());
 		ChatRoomEntity chatRoom = chatRoomRepository.save(chatRoomEntity);
 

--- a/backend/src/test/java/mouda/backend/chat/business/ChatServiceTest.java
+++ b/backend/src/test/java/mouda/backend/chat/business/ChatServiceTest.java
@@ -257,7 +257,7 @@ class ChatServiceTest extends DarakbangSetUp {
 			ChatRoomEntityFixture.getChatRoomEntityOfMoim(savedMoim.getId(), darakbang.getId()));
 
 		chatRepository.save(ChatEntityFixture.getChatEntity(darakbangHogee));
-		chatRepository.save(ChatEntityFixture.getChatEntity(darakbangHogee));
+		chatRepository.save(ChatEntityFixture.getChatEntity(darakbangAnna));
 		chatRepository.save(ChatEntityFixture.getChatEntity(darakbangHogee));
 
 		// when
@@ -266,6 +266,10 @@ class ChatServiceTest extends DarakbangSetUp {
 
 		// then
 		assertThat(unloadedChats.chats()).hasSize(2);
+		assertThat(unloadedChats.chats().get(0).isMyMessage()).isFalse();
+		assertThat(unloadedChats.chats().get(0).participation().nickname()).isEqualTo(darakbangAnna.getNickname());
+		assertThat(unloadedChats.chats().get(1).isMyMessage()).isTrue();
+		assertThat(unloadedChats.chats().get(1).participation().nickname()).isEqualTo(darakbangHogee.getNickname());
 	}
 
 	@DisplayName("열린 채팅방이 없다면 빈 리스트를 반환한다.")

--- a/backend/src/test/java/mouda/backend/chat/implement/BetAttributeManagerTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/BetAttributeManagerTest.java
@@ -83,7 +83,7 @@ class BetAttributeManagerTest {
 		when(darakbang.getId()).thenReturn(1L);
 
 		when(betFinder.find(1L, 1L)).thenReturn(bet);
-		when(bet.getBetDetails()).thenReturn(new BetDetails(1L, "test bet", LocalDateTime.of(2024, 6, 5, 12, 3)));
+		when(bet.getBetDetails()).thenReturn(new BetDetails(1L, "test bet", LocalDateTime.of(2024, 6, 5, 12, 3), null));
 		when(bet.isLoser(darakbangMember.getId())).thenReturn(true);
 		when(bet.getId()).thenReturn(1L);
 		when(bet.getLoserId()).thenReturn(2L);

--- a/backend/src/test/java/mouda/backend/chat/implement/BetAttributeManagerTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/BetAttributeManagerTest.java
@@ -83,7 +83,8 @@ class BetAttributeManagerTest {
 		when(darakbang.getId()).thenReturn(1L);
 
 		when(betFinder.find(1L, 1L)).thenReturn(bet);
-		when(bet.getBetDetails()).thenReturn(new BetDetails(1L, "test bet", LocalDateTime.of(2024, 6, 5, 12, 3), null));
+		when(bet.getBetDetails()).thenReturn(
+			new BetDetails(1L, "test bet", LocalDateTime.of(2024, 6, 5, 12, 3), 1L, null));
 		when(bet.isLoser(darakbangMember.getId())).thenReturn(true);
 		when(bet.getId()).thenReturn(1L);
 		when(bet.getLoserId()).thenReturn(2L);

--- a/backend/src/test/java/mouda/backend/chat/implement/BetChatPreviewManagerTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/BetChatPreviewManagerTest.java
@@ -43,23 +43,19 @@ class BetChatPreviewManagerTest extends DarakbangSetUp {
 		assertThat(chatPreviews).isEmpty();
 	}
 
-	@DisplayName("안내면진다 채팅방 목록을 조회한다.")
+	@DisplayName("채팅방 목록에서 추첨 후 채팅방이 열린 안내면진다만 조회한다.")
 	@Test
 	void create() {
 		// given
-		BetEntity betEntity1 = BetEntityFixture.getBetEntity(darakbangAnna.getId(), 1L);
+		BetEntity betEntity1 = BetEntityFixture.getDrawedBetEntity(darakbangAnna.getId(), 1L);
 		BetEntity betEntity2 = BetEntityFixture.getBetEntity(darakbangAnna.getId(), 1L);
-		betRepository.save(betEntity1);
-		betRepository.save(betEntity2);
-		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangHogee, betEntity1));
-		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangHogee, betEntity2));
+		BetEntity savedBet1 = betRepository.save(betEntity1);
+		BetEntity savedBet2 = betRepository.save(betEntity2);
+		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangHogee, savedBet1));
+		betDarakbangMemberRepository.save(new BetDarakbangMemberEntity(darakbangHogee, savedBet2));
 
-		ChatRoomEntity chatRoom1 = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity1.getId(),
-			darakbang.getId());
-		ChatRoomEntity chatRoom2 = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity2.getId(),
-			darakbang.getId());
+		ChatRoomEntity chatRoom1 = ChatRoomEntityFixture.getChatRoomEntityOfBet(savedBet1.getId(), darakbang.getId());
 		chatRoomRepository.save(chatRoom1);
-		chatRoomRepository.save(chatRoom2);
 
 		// when
 		List<ChatPreview> chatPreviews = betChatPreviewManager.create(darakbangHogee);
@@ -67,6 +63,6 @@ class BetChatPreviewManagerTest extends DarakbangSetUp {
 		// then
 		assertThat(chatPreviews)
 			.isNotEmpty()
-			.hasSize(2);
+			.hasSize(1);
 	}
 }

--- a/backend/src/test/java/mouda/backend/chat/implement/BetParticipantResolverTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/BetParticipantResolverTest.java
@@ -48,9 +48,10 @@ class BetParticipantResolverTest extends DarakbangSetUp {
 		betDarakbangMemberRepository.save(annaEntity);
 		betDarakbangMemberRepository.save(hogeeEntity);
 
-		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity.getId(), darakbang.getId());
-		ChatRoomEntity savedChatRoomEntity = chatRoomRepository.save(chatRoomEntity);
-		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity);
+		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity.getId(),
+			darakbang.getId());
+		ChatRoomEntity savedChatRoom = chatRoomRepository.save(chatRoomEntity);
+		ChatRoom chatRoom = new ChatRoom(savedChatRoom.getId(), savedChatRoom.getTargetId(), savedChatRoom.getType());
 
 		// when
 		List<Participant> participants = betParticipantResolver.resolve(chatRoom);

--- a/backend/src/test/java/mouda/backend/chat/implement/ChatRoomDetailsFinderTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/ChatRoomDetailsFinderTest.java
@@ -73,16 +73,19 @@ class ChatRoomDetailsFinderTest extends DarakbangSetUp {
 
 		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfMoim(moim.getId(), darakbang.getId());
 		ChatRoomEntity savedChatRoomEntity = chatRoomRepository.save(chatRoomEntity);
-		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity);
+		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity.getId(), savedChatRoomEntity.getTargetId(),
+			savedChatRoomEntity.getType());
 
 		// when
-		ChatRoomDetails chatRoomDetails = chatRoomDetailsFinder.find(darakbang.getId(), chatRoom.getId(), darakbangAnna);
+		ChatRoomDetails chatRoomDetails = chatRoomDetailsFinder.find(darakbang.getId(), chatRoom.getId(),
+			darakbangAnna);
 
 		// then
 		assertThat(chatRoomDetails.getChatRoomType()).isEqualTo(ChatRoomType.MOIM);
 		assertThat(chatRoomDetails.getTitle()).isEqualTo("커피 마실 사람?");
 		assertThat(chatRoomDetails.getId()).isEqualTo(chatRoom.getId());
-		assertThat(chatRoomDetails.getParticipants()).containsExactly(new Participant("anna", "profile", "MOIMER"), new Participant("hogee", "profile", "MOIMEE"));
+		assertThat(chatRoomDetails.getParticipants()).containsExactly(new Participant("anna", "profile", "MOIMER"),
+			new Participant("hogee", "profile", "MOIMEE"));
 		assertThat(chatRoomDetails.getAttributes())
 			.containsExactlyInAnyOrderEntriesOf(getExpectedMoimAttributes(savedMoim));
 	}
@@ -112,18 +115,22 @@ class ChatRoomDetailsFinderTest extends DarakbangSetUp {
 		betDarakbangMemberRepository.save(annaEntity);
 		betDarakbangMemberRepository.save(hogeeEntity);
 
-		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity.getId(), darakbang.getId());
+		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfBet(betEntity.getId(),
+			darakbang.getId());
 		ChatRoomEntity savedChatRoomEntity = chatRoomRepository.save(chatRoomEntity);
-		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity);
+		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity.getId(), savedChatRoomEntity.getTargetId(),
+			savedChatRoomEntity.getType());
 
 		// when
-		ChatRoomDetails chatRoomDetails = chatRoomDetailsFinder.find(darakbang.getId(), chatRoom.getId(), darakbangAnna);
+		ChatRoomDetails chatRoomDetails = chatRoomDetailsFinder.find(darakbang.getId(), chatRoom.getId(),
+			darakbangAnna);
 
 		// then
 		assertThat(chatRoomDetails.getChatRoomType()).isEqualTo(ChatRoomType.BET);
 		assertThat(chatRoomDetails.getTitle()).isEqualTo("테바바보");
 		assertThat(chatRoomDetails.getId()).isEqualTo(chatRoom.getId());
-		assertThat(chatRoomDetails.getParticipants()).containsExactly(new Participant("anna", "profile", "MOIMER"), new Participant("hogee", "profile", "MOIMEE"));
+		assertThat(chatRoomDetails.getParticipants()).containsExactly(new Participant("anna", "profile", "MOIMER"),
+			new Participant("hogee", "profile", "MOIMEE"));
 		assertThat(chatRoomDetails.getAttributes())
 			.containsExactlyInAnyOrderEntriesOf(getExpectedBetAttributes(savedBetEntity));
 	}

--- a/backend/src/test/java/mouda/backend/chat/implement/MoimParticipantResolverTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/MoimParticipantResolverTest.java
@@ -59,7 +59,8 @@ class MoimParticipantResolverTest extends DarakbangSetUp {
 
 		ChatRoomEntity chatRoomEntity = ChatRoomEntityFixture.getChatRoomEntityOfMoim(moim.getId(), darakbang.getId());
 		ChatRoomEntity savedChatRoomEntity = chatRoomRepository.save(chatRoomEntity);
-		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity);
+		ChatRoom chatRoom = new ChatRoom(savedChatRoomEntity.getId(), savedChatRoomEntity.getTargetId(),
+			savedChatRoomEntity.getType());
 
 		// when
 		List<Participant> participants = moimParticipantResolver.resolve(chatRoom);

--- a/backend/src/test/java/mouda/backend/common/fixture/BetEntityFixture.java
+++ b/backend/src/test/java/mouda/backend/common/fixture/BetEntityFixture.java
@@ -6,46 +6,58 @@ import mouda.backend.bet.entity.BetEntity;
 
 public class BetEntityFixture {
 
-    public static BetEntity getBetEntity(long darakbangId, long moimerId) {
-        return BetEntity.builder()
-            .title("testBet")
-            .bettingTime(LocalDateTime.now()
-                .withSecond(0)
-                .withNano(0))
-            .darakbangId(darakbangId)
-            .moimerId(moimerId)
-            .build();
-    }
+	public static BetEntity getBetEntity(long darakbangId, long moimerId) {
+		return BetEntity.builder()
+			.title("testBet")
+			.bettingTime(LocalDateTime.now()
+				.withSecond(0)
+				.withNano(0))
+			.darakbangId(darakbangId)
+			.moimerId(moimerId)
+			.build();
+	}
 
-    public static BetEntity getBetEntity(String title, long darakbangId, long moimerId) {
-        return BetEntity.builder()
-            .title(title)
-            .bettingTime(LocalDateTime.now()
-                .withSecond(0)
-                .withNano(0))
-            .darakbangId(darakbangId)
-            .moimerId(moimerId)
-            .build();
-    }
+	public static BetEntity getFutureBetEntity(long darakbangId, long moimerId) {
+		return BetEntity.builder()
+			.title("testBet")
+			.bettingTime(LocalDateTime.now()
+				.plusMinutes(10)
+				.withSecond(0)
+				.withNano(0))
+			.darakbangId(darakbangId)
+			.moimerId(moimerId)
+			.build();
+	}
 
-    public static BetEntity getBetEntity(long darakbangId, long moimerId, LocalDateTime bettingTime) {
-        return BetEntity.builder()
-            .title("테바바보")
-            .bettingTime(bettingTime.withSecond(0).withNano(0))
-            .darakbangId(darakbangId)
-            .moimerId(moimerId)
-            .build();
-    }
+	public static BetEntity getBetEntity(String title, long darakbangId, long moimerId) {
+		return BetEntity.builder()
+			.title(title)
+			.bettingTime(LocalDateTime.now()
+				.withSecond(0)
+				.withNano(0))
+			.darakbangId(darakbangId)
+			.moimerId(moimerId)
+			.build();
+	}
 
-    public static BetEntity getDrawedBetEntity(long darakbangId, long moimerId) {
-        return BetEntity.builder()
-            .title("테바바보")
-            .bettingTime(LocalDateTime.now()
-                .withSecond(0)
-                .withNano(0))
-            .darakbangId(darakbangId)
-            .moimerId(moimerId)
-            .loserDarakbangMemberId(moimerId)
-            .build();
-    }
+	public static BetEntity getBetEntity(long darakbangId, long moimerId, LocalDateTime bettingTime) {
+		return BetEntity.builder()
+			.title("테바바보")
+			.bettingTime(bettingTime.withSecond(0).withNano(0))
+			.darakbangId(darakbangId)
+			.moimerId(moimerId)
+			.build();
+	}
+
+	public static BetEntity getDrawedBetEntity(long darakbangId, long moimerId) {
+		return BetEntity.builder()
+			.title("테바바보")
+			.bettingTime(LocalDateTime.now()
+				.withSecond(0)
+				.withNano(0))
+			.darakbangId(darakbangId)
+			.moimerId(moimerId)
+			.loserDarakbangMemberId(moimerId)
+			.build();
+	}
 }

--- a/backend/src/test/java/mouda/backend/common/fixture/DarakbangMemberFixture.java
+++ b/backend/src/test/java/mouda/backend/common/fixture/DarakbangMemberFixture.java
@@ -29,6 +29,17 @@ public class DarakbangMemberFixture {
 			.build();
 	}
 
+	public static DarakbangMember getDarakbangMemberWithWooteco(Member member) {
+		return DarakbangMember.builder()
+			.darakbang(DarakbangFixture.getDarakbangWithMouda())
+			.memberId(member.getId())
+			.nickname(member.getName())
+			.profile("profile")
+			.description("description")
+			.role(DarakBangMemberRole.MEMBER)
+			.build();
+	}
+
 	public static DarakbangMember getDarakbangOutsiderWithWooteco(Darakbang darakbang, Member member) {
 		return DarakbangMember.builder()
 			.darakbang(darakbang)


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

**채팅 버그 수정**
- 채팅을 보낸 사람이 모두 자신의 프로필로 나오는 버그 수정
- 채팅방이 존재하지 않는 안내면진다를 목록에서 조회하려고 함에 따른 버그 수정


**안내면진다 예외 처리**
- 중복 참여 예외
- 당첨자 이미 존재하는 경우 참여 예외
- 추첨시간 이후 참여 예외

## 이슈 ID는 무엇인가요?

- close #653 

## 설명

- chat을 보낸 사람의 정보로 변경
- 안내면진다에서 당첨자가 없는 것(채팅방이 없는 것)은 preview 조회에서 제외
- Role이 MEMBER, MANAGER 로 나오는 오류 수정

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
