### PR TITLE
사용자 인증에서 카카오 계정 전환 엣지 케이스 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
@@ -19,6 +19,7 @@ public class AccessTokenProvider {
 
 	public static final String MEMBER_ID_CLAIM_KEY = "id";
 	public static final String SOCIAL_LOGIN_ID_CLAIM_KEY = "socialLoginId";
+	private static final String OAUTH_TYPE = "oauthType";
 
 	@Value("${security.jwt.token.secret-key}")
 	private String secretKey;
@@ -33,6 +34,7 @@ public class AccessTokenProvider {
 		return Jwts.builder()
 			.claim(MEMBER_ID_CLAIM_KEY, member.getId())
 			.claim(SOCIAL_LOGIN_ID_CLAIM_KEY, member.getSocialLoginId())
+			.claim(OAUTH_TYPE, member.getOauthType())
 			.setIssuedAt(now)
 			.setExpiration(validity)
 			.signWith(SignatureAlgorithm.HS256, secretKey)

--- a/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import mouda.backend.auth.exception.AuthErrorMessage;
 import mouda.backend.auth.exception.AuthException;
 import mouda.backend.member.domain.Member;
+import mouda.backend.member.domain.OauthType;
 
 @Component
 public class AccessTokenProvider {
@@ -58,10 +59,13 @@ public class AccessTokenProvider {
 		}
 	}
 
-	public void validateExpiration(String token) {
+	public void validateToken(String token) {
 		Claims claims = getPayload(token);
 
 		if (claims.getExpiration().before(new Date())) {
+			throw new AuthException(HttpStatus.UNAUTHORIZED, AuthErrorMessage.UNAUTHORIZED);
+		}
+		if (claims.get(OAUTH_TYPE) == OauthType.KAKAO.toString()) {
 			throw new AuthException(HttpStatus.UNAUTHORIZED, AuthErrorMessage.UNAUTHORIZED);
 		}
 	}

--- a/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/jwt/AccessTokenProvider.java
@@ -18,8 +18,8 @@ import mouda.backend.member.domain.OauthType;
 @Component
 public class AccessTokenProvider {
 
-	public static final String MEMBER_ID_CLAIM_KEY = "id";
-	public static final String SOCIAL_LOGIN_ID_CLAIM_KEY = "socialLoginId";
+	private static final String MEMBER_ID_CLAIM_KEY = "id";
+	private static final String SOCIAL_LOGIN_ID_CLAIM_KEY = "socialLoginId";
 	private static final String OAUTH_TYPE = "oauthType";
 
 	@Value("${security.jwt.token.secret-key}")
@@ -65,7 +65,7 @@ public class AccessTokenProvider {
 		if (claims.getExpiration().before(new Date())) {
 			throw new AuthException(HttpStatus.UNAUTHORIZED, AuthErrorMessage.UNAUTHORIZED);
 		}
-		if (claims.get(OAUTH_TYPE) == OauthType.KAKAO.toString()) {
+		if (claims.get(OAUTH_TYPE).equals(OauthType.KAKAO.toString())) {
 			throw new AuthException(HttpStatus.UNAUTHORIZED, AuthErrorMessage.UNAUTHORIZED);
 		}
 	}

--- a/backend/src/main/java/mouda/backend/member/business/MemberService.java
+++ b/backend/src/main/java/mouda/backend/member/business/MemberService.java
@@ -22,6 +22,6 @@ public class MemberService {
 	}
 
 	public void checkAuthentication(String token) {
-		accessTokenProvider.validateExpiration(token);
+		accessTokenProvider.validateToken(token);
 	}
 }

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -46,6 +46,10 @@ public class Member {
 		return loginDetail.getSocialLoginId();
 	}
 
+	public String getOauthType() {
+		return loginDetail.getOauthType().toString();
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

사용자 인증에서 카카오 계정 전환 엣지 케이스 수정

## 이슈 ID는 무엇인가요?

- #668 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

현재 카카오 계정 전환 플로우는 다음과 같습니다.
1. 카카오 로그인을 한다.
2. 멤버 id 와 accessToken 을 발급한다.
3. 구글 or 애플 로그인을 한다.
4. 프론트에게 구글 or 애플의 사용자 정보와 아까 받은 memberId 를 받는다.
5. 만약 memberId 가 있다면 카카오 회원이기 때문에 전환 과정을 실행한다.
6. memberId가 없다면 카카오 회원이 아니기 때문에 새로운 멤버를 생성한다.

만약 사용자가 카카오 로그인만 진행 후 밖으로 나온다면
accessToken 을 가지고 있는 상태가 됨
이를 처리하기 위해 accessToken 에 OauthType을 추가한다.
인터셉터에서 OauthType이 Kakao 인 토큰을 가지고 접근하려고 하면 예외를 발생

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
