### PR TITLE
안내면진다 목록 정렬 수정 및 모임 상세 응답에서 ChatRoomId 추가

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/implement/BetSorter.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetSorter.java
@@ -11,17 +11,14 @@ import mouda.backend.bet.domain.Bet;
 @Component
 public class BetSorter {
 
-    private static final int HAS_LOSER = 1;
-    private static final int NO_LOSER = 0;
+	public List<Bet> sort(List<Bet> bets) {
+		List<Bet> mutableBets = new ArrayList<>(bets);
 
-    public List<Bet> sort(List<Bet> bets) {
-        List<Bet> mutableBets = new ArrayList<>(bets);
+		mutableBets.sort(Comparator
+			.comparing(Bet::hasLoser)
+			.thenComparing(Bet::timeDifferenceInMinutesWithNow)
+		);
 
-        mutableBets.sort(Comparator
-            .comparing(Bet::timeDifferenceInMinutesWithNow)
-            .thenComparing(bet -> bet.hasLoser() ? HAS_LOSER : NO_LOSER)
-        );
-
-        return mutableBets;
-    }
+		return mutableBets;
+	}
 }

--- a/backend/src/main/java/mouda/backend/moim/business/MoimService.java
+++ b/backend/src/main/java/mouda/backend/moim/business/MoimService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import mouda.backend.chat.domain.ChatRoomType;
+import mouda.backend.chat.implement.ChatRoomFinder;
 import mouda.backend.darakbangmember.domain.DarakbangMember;
 import mouda.backend.moim.domain.FilterType;
 import mouda.backend.moim.domain.Moim;
@@ -31,6 +33,7 @@ public class MoimService {
 	private final MoimFinder moimFinder;
 	private final CommentFinder commentFinder;
 	private final MoimNotificationSender moimNotificationSender;
+	private final ChatRoomFinder chatRoomFinder;
 
 	@Transactional(readOnly = true)
 	public MoimDetailsFindResponse findMoimDetails(long darakbangId, long moimId) {
@@ -39,7 +42,14 @@ public class MoimService {
 		List<ParentComment> parentComments = commentFinder.readAllParentComments(moim);
 		CommentResponses commentResponses = CommentResponses.toResponse(parentComments);
 
-		return MoimDetailsFindResponse.toResponse(moim, moimFinder.countCurrentPeople(moim), commentResponses);
+		Long chatRoomId = chatRoomFinder.findChatRoomIdByTargetId(moim.getId(), ChatRoomType.MOIM);
+
+		return MoimDetailsFindResponse.toResponse(
+			moim,
+			moimFinder.countCurrentPeople(moim),
+			commentResponses,
+			chatRoomId
+		);
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/src/main/java/mouda/backend/moim/presentation/response/moim/MoimDetailsFindResponse.java
+++ b/backend/src/main/java/mouda/backend/moim/presentation/response/moim/MoimDetailsFindResponse.java
@@ -20,10 +20,16 @@ public record MoimDetailsFindResponse(
 	String authorNickname,
 	String description,
 	String status,
-	List<CommentResponse> comments
+	List<CommentResponse> comments,
+	Long chatRoomId
 ) {
 
-	public static MoimDetailsFindResponse toResponse(Moim moim, int currentPeople, CommentResponses comments) {
+	public static MoimDetailsFindResponse toResponse(
+		Moim moim,
+		int currentPeople,
+		CommentResponses comments,
+		Long chatRoomId
+	) {
 		String time = moim.getTime() == null ? "" : moim.getTime().format(ofPattern("HH:mm"));
 		String date = moim.getDate() == null ? "" : moim.getDate().format(ISO_LOCAL_DATE);
 		String place = moim.getPlace() == null ? "" : moim.getPlace();
@@ -37,6 +43,7 @@ public record MoimDetailsFindResponse(
 			.description(moim.getDescription())
 			.status(moim.getMoimStatus().name())
 			.comments(comments.commentResponses())
+			.chatRoomId(chatRoomId)
 			.build();
 	}
 }

--- a/backend/src/test/java/mouda/backend/bet/implement/BetSorterTest.java
+++ b/backend/src/test/java/mouda/backend/bet/implement/BetSorterTest.java
@@ -15,45 +15,63 @@ import mouda.backend.common.fixture.BetFixture;
 
 public class BetSorterTest {
 
-    private BetSorter betSorter;
+	private BetSorter betSorter;
 
-    @BeforeEach
-    public void setUp() {
-        betSorter = new BetSorter();
-    }
+	@BeforeEach
+	public void setUp() {
+		betSorter = new BetSorter();
+	}
 
-    @DisplayName("현재 시간과의 차이가 적은 순서대로 정렬한다.")
-    @Test
-    public void sortByTimeDifference() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        Bet bet1 = BetFixture.createBet(1L, now.plusMinutes(5), null);
-        Bet bet2 = BetFixture.createBet(2L, now.plusMinutes(1), null);
-        Bet bet3 = BetFixture.createBet(3L, now.plusMinutes(10), null);
-        Bet bet4 = BetFixture.createBet(4L, now.minusMinutes(3), null);
+	@DisplayName("현재 시간과의 차이가 적은 순서대로 정렬한다.")
+	@Test
+	public void sortByTimeDifference() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Bet bet1 = BetFixture.createBet(1L, now.plusMinutes(5), null);
+		Bet bet2 = BetFixture.createBet(2L, now.plusMinutes(1), null);
+		Bet bet3 = BetFixture.createBet(3L, now.plusMinutes(10), null);
+		Bet bet4 = BetFixture.createBet(4L, now.minusMinutes(3), null);
 
-        // when
-        List<Bet> bets = Arrays.asList(bet1, bet2, bet3, bet4);
-        List<Bet> sortedBets = betSorter.sort(bets);
+		// when
+		List<Bet> bets = Arrays.asList(bet1, bet2, bet3, bet4);
+		List<Bet> sortedBets = betSorter.sort(bets);
 
-        // then
-        assertThat(sortedBets).containsExactly(bet2, bet4, bet1, bet3);
-    }
+		// then
+		assertThat(sortedBets).containsExactly(bet2, bet4, bet1, bet3);
+	}
 
-    @DisplayName("시간이 같으면 추첨이 완료되지 않은 배팅이 먼저 배치된다.")
-    @Test
-    public void sortByLoserIdWhenTimeIsEqual() {
-        // given
-        LocalDateTime now = LocalDateTime.now();
-        Bet bet1 = BetFixture.createBet(1L, now.plusMinutes(5), null);
-        Bet bet2 = BetFixture.createBet(2L, now.plusMinutes(1), 100L);
-        Bet bet3 = BetFixture.createBet(3L, now.plusMinutes(1), null);
+	@DisplayName("모든 베팅이 추첨되었다면 추첨시간과 가까운 순으로 배치한다.")
+	@Test
+	public void sortByLoserIdWhenTimeIsEqual() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Bet bet1 = BetFixture.createBet(1L, now.plusMinutes(5), 100L);
+		Bet bet2 = BetFixture.createBet(2L, now.plusMinutes(1), 100L);
+		Bet bet3 = BetFixture.createBet(3L, now.plusMinutes(3), 100L);
 
-        // when
-        List<Bet> bets = Arrays.asList(bet1, bet2, bet3);
-        List<Bet> sortedBets = betSorter.sort(bets);
+		// when
+		List<Bet> bets = Arrays.asList(bet1, bet2, bet3);
+		List<Bet> sortedBets = betSorter.sort(bets);
 
-        // then
-        assertThat(sortedBets).containsExactly(bet3, bet2, bet1);
-    }
+		// then
+		assertThat(sortedBets).containsExactly(bet2, bet3, bet1);
+	}
+
+	@DisplayName("추첨이 완료되지 않은 배팅이 추첨시간과 가까운 순으로 먼저 배치된다. 추첨된 베팅은 추첨시간과 가까운 순으로 뒤에 배치된다.")
+	@Test
+	public void sortByHasLoser() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Bet bet1 = BetFixture.createBet(1L, now.plusMinutes(5), null);
+		Bet bet2 = BetFixture.createBet(2L, now.plusMinutes(1), 100L);
+		Bet bet3 = BetFixture.createBet(3L, now.plusMinutes(1), null);
+		Bet bet4 = BetFixture.createBet(4L, now.plusMinutes(5), 100L);
+
+		// when
+		List<Bet> bets = Arrays.asList(bet1, bet2, bet3, bet4);
+		List<Bet> sortedBets = betSorter.sort(bets);
+
+		// then
+		assertThat(sortedBets).containsExactly(bet3, bet1, bet2, bet4);
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

- 안내면진다 목록 정렬 수정
  1. 마감하지 않은 베팅 (임박 순)
  2. 마감한 베팅 (임박 순)
- 모임 상세 응답에서 chatRoom으로 넘어가는 정보 누락
  - MoimDetailsFindResponse에 chatRoomId 추가
  - nullable

## 이슈 ID는 무엇인가요?

- close #676 

## 설명

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
