### PR TITLE
푸시 알림 클릭시 이동 문제 확인

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -20,7 +20,7 @@ self.addEventListener('notificationclick', function (event) {
   // console.log('[firebase-messaging-sw.js] 알림이 클릭되었습니다.');
 
   // 알림 데이터를 가져오기
-  const link = event.notification.data.FCM_MSG.notification.click_action;
+  const link = event.notification.data.FCM_MSG.data.link;
 
   event.notification.close(); // 알림 닫기
 

--- a/frontend/src/service/forgroundMessage.ts
+++ b/frontend/src/service/forgroundMessage.ts
@@ -12,7 +12,7 @@ function initializeForegroundMessageHandling() {
     const notificationOptions = {
       body: payload.notification?.body || '',
       icon: payload.notification?.icon,
-      data: { link: payload.fcmOptions?.link || '/' },
+      data: { link: payload.data?.link || '/' },
     };
 
     if (Notification.permission === 'granted') {


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

백엔드에서 푸시 알림 클릭시 이동 경로를 보내주는 방법을 수정해서, 프론트 코드에 반영했어요.

## 이슈 ID는 무엇인가요?

- #680 

## 설명

테스트를 하는 도중 뒤로가기 버튼을 눌렀을 때 이동하지 않아서 몇 시간을 헤맸는데.. 
최신 코드가 아니어서 그랬네요.. 제 테스트 환경 코드에서는 아래처럼 되어있었거든요..
```
<ChattingRoomLayout.Header.Left>
  <div onClick={() => navigate(-1)}>
    <Back />
  </div>
</ChattingRoomLayout.Header.Left>
```

최신 코드에서는 해당 부분이 전부 수정이 되어있더라구요? 그래서 link를 가져오는 방법만 서버에서 변경한 내용대로 반영하니 모두 해결됐습니다.


## 질문 혹은 공유 사항 (Optional)

프론트분들이 작업할 내용이 많은 것 같아 큰 변경사항도 없어 제가 그냥 작업했습니다.
테스트는 제 개인 EC2에 배포하고 정상 동작은 확인했어요~


