### PR TITLE
회원 탈퇴 시 논리 삭제 및 재가입 로직 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/auth/Infrastructure/AppleOauthClient.java
+++ b/backend/src/main/java/mouda/backend/auth/Infrastructure/AppleOauthClient.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -58,22 +57,23 @@ public class AppleOauthClient implements OauthClient {
 		return response.refresh_token();
 	}
 
-	public void revoke(String refreshToken) {
-		String revokeUrl = APPLE_API_URL + "/oauth2/v2/revoke";
-		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
-		formData.add("client_id", CLIENT_ID);
-		formData.add("client_secret", clientSecretProvider.provide());
-		formData.add("token", refreshToken);
-		formData.add("token_hint_type", "refresh_token");
-
-		ResponseEntity<String> result = restClient.method(HttpMethod.POST)
-			.uri(revokeUrl)
-			.headers(httpHeaders -> httpHeaders.addAll(getHttpHeaders()))
-			.body(formData)
-			.retrieve()
-			.toEntity(String.class);
-		log.info("revoke status code : {}", result.getStatusCode());
-	}
+	// TODO: 애플 심사 시 필요할 수 있으므로 제거하지 않습니다.
+	// public void revoke(String refreshToken) {
+	// 	String revokeUrl = APPLE_API_URL + "/oauth2/v2/revoke";
+	// 	MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+	// 	formData.add("client_id", CLIENT_ID);
+	// 	formData.add("client_secret", clientSecretProvider.provide());
+	// 	formData.add("token", refreshToken);
+	// 	formData.add("token_hint_type", "refresh_token");
+	//
+	// 	ResponseEntity<String> result = restClient.method(HttpMethod.POST)
+	// 		.uri(revokeUrl)
+	// 		.headers(httpHeaders -> httpHeaders.addAll(getHttpHeaders()))
+	// 		.body(formData)
+	// 		.retrieve()
+	// 		.toEntity(String.class);
+	// 	log.info("revoke status code : {}", result.getStatusCode());
+	// }
 
 	private MultiValueMap<String, String> getFormData(String code) {
 		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -65,7 +65,6 @@ public class AppleAuthService {
 
 	private void saveMember(String idToken, String firstName, String lastName) {
 		String socialLoginId = appleOauthManager.getSocialLoginId(idToken);
-		log.info("socialLoginId = " + socialLoginId);
 		Member member = new Member(lastName + firstName, new LoginDetail(OauthType.APPLE, socialLoginId));
 		memberWriter.append(member);
 	}

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -52,21 +52,20 @@ public class AppleAuthService {
 		return accessTokenProvider.provide(member);
 	}
 
-	public void save(String code, String idToken, String user) {
-		String refreshToken = appleOauthClient.getRefreshToken(code);
+	public void save(String idToken, String user) {
 		try {
 			AppleUserInfoRequest request = objectMapper.readValue(user, AppleUserInfoRequest.class);
 			String firstName = request.name().firstName();
 			String lastName = request.name().lastName();
-			saveMember(refreshToken, idToken, firstName, lastName);
+			saveMember(idToken, firstName, lastName);
 		} catch (JsonProcessingException exception) {
 			throw new AuthException(HttpStatus.BAD_REQUEST, AuthErrorMessage.APPLE_USER_BAD_REQUEST);
 		}
 	}
 
-	private void saveMember(String refreshToken, String idToken, String firstName, String lastName) {
+	private void saveMember(String idToken, String firstName, String lastName) {
 		String socialLoginId = appleOauthManager.getSocialLoginId(idToken);
-		Member member = new Member(lastName + firstName, new LoginDetail(OauthType.APPLE, socialLoginId, refreshToken));
+		Member member = new Member(lastName + firstName, new LoginDetail(OauthType.APPLE, socialLoginId));
 		memberWriter.append(member);
 	}
 }

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -65,6 +65,7 @@ public class AppleAuthService {
 
 	private void saveMember(String idToken, String firstName, String lastName) {
 		String socialLoginId = appleOauthManager.getSocialLoginId(idToken);
+		log.info("socialLoginId = " + socialLoginId);
 		Member member = new Member(lastName + firstName, new LoginDetail(OauthType.APPLE, socialLoginId));
 		memberWriter.append(member);
 	}

--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import mouda.backend.auth.Infrastructure.AppleOauthClient;
 import mouda.backend.auth.exception.AuthErrorMessage;
 import mouda.backend.auth.exception.AuthException;
 import mouda.backend.auth.implement.AppleOauthManager;
@@ -19,20 +18,17 @@ import mouda.backend.member.domain.Member;
 import mouda.backend.member.domain.OauthType;
 import mouda.backend.member.implement.MemberFinder;
 import mouda.backend.member.implement.MemberWriter;
-import mouda.backend.member.infrastructure.MemberRepository;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleAuthService {
 
-	private final MemberRepository memberRepository;
 	private final MemberFinder memberFinder;
 	private final MemberWriter memberWriter;
 	private final AppleOauthManager appleOauthManager;
 	private final AccessTokenProvider accessTokenProvider;
 	private final ObjectMapper objectMapper;
-	private final AppleOauthClient appleOauthClient;
 
 	// TODO: 더 이상 사용하지 않는 로직. 로그인 프로세스 정착 후 제거할 것
 	// public LoginResponse oauthLogin(AppleOauthRequest oauthRequest) {
@@ -43,7 +39,7 @@ public class AppleAuthService {
 	// 	return new LoginResponse(accessToken);
 	// }
 	// LoginProcessResult result = loginManager.processAppleLogin(member);
-	// return new LoginResponse(result.accessToken());ap
+	// return new LoginResponse(result.accessToken());
 	// }
 
 	public String login(String idToken) {

--- a/backend/src/main/java/mouda/backend/auth/business/KakaoAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/KakaoAuthService.java
@@ -10,7 +10,6 @@ import mouda.backend.auth.implement.KakaoOauthManager;
 import mouda.backend.auth.implement.LoginManager;
 import mouda.backend.auth.implement.jwt.AccessTokenProvider;
 import mouda.backend.auth.presentation.request.OauthRequest;
-import mouda.backend.auth.presentation.response.KakaoLoginResponse;
 import mouda.backend.auth.presentation.response.LoginResponse;
 import mouda.backend.member.domain.LoginDetail;
 import mouda.backend.member.domain.Member;
@@ -28,11 +27,11 @@ public class KakaoAuthService {
 	private final MemberWriter memberWriter;
 	private final MemberFinder memberFinder;
 
-	public KakaoLoginResponse oauthLogin(OauthRequest oauthRequest) {
+	public LoginResponse oauthLogin(OauthRequest oauthRequest) {
 		String kakaoId = oauthManager.getSocialLoginId(oauthRequest.code());
 		LoginProcessResult loginProcessResult = loginManager.processSocialLogin(OauthType.KAKAO, kakaoId, "name");
 
-		return new KakaoLoginResponse(loginProcessResult.memberId(), loginProcessResult.accessToken());
+		return new LoginResponse(loginProcessResult.accessToken());
 	}
 
 	public LoginResponse basicLoginAnna() {

--- a/backend/src/main/java/mouda/backend/auth/business/result/LoginProcessResult.java
+++ b/backend/src/main/java/mouda/backend/auth/business/result/LoginProcessResult.java
@@ -1,7 +1,6 @@
 package mouda.backend.auth.business.result;
 
 public record LoginProcessResult(
-	Long memberId,
 	String accessToken
 ) {
 }

--- a/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
@@ -32,7 +32,7 @@ public class LoginManager {
 			return signup(oauthType, socialLoginId, name);
 		}
 		if (member.get().isDeleted()) {
-			member.get().resignup(); // TODO: 더티 체킹이 가능할까?
+			member.get().reSignup(); // TODO: 더티 체킹이 가능할까?
 		}
 		return new LoginProcessResult(accessTokenProvider.provide(member.get()));
 	}

--- a/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/LoginManager.java
@@ -32,8 +32,10 @@ public class LoginManager {
 			return signup(oauthType, socialLoginId, name);
 		}
 		if (member.get().isDeleted()) {
-			member.get().reSignup(); // TODO: 더티 체킹이 가능할까?
+			member.get().reSignup();
+			memberRepository.save(member.get());
 		}
+		memberWriter.updateName(member.get().getId(), name);
 		return new LoginProcessResult(accessTokenProvider.provide(member.get()));
 	}
 

--- a/backend/src/main/java/mouda/backend/auth/presentation/business/CommonAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/business/CommonAuthService.java
@@ -5,9 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import mouda.backend.auth.Infrastructure.AppleOauthClient;
 import mouda.backend.member.domain.Member;
-import mouda.backend.member.domain.OauthType;
 import mouda.backend.member.implement.MemberWriter;
 
 @Slf4j
@@ -16,14 +14,9 @@ import mouda.backend.member.implement.MemberWriter;
 @RequiredArgsConstructor
 public class CommonAuthService {
 
-	private final AppleOauthClient oauthClient;
 	private final MemberWriter memberWriter;
 
 	public void withdraw(Member member) {
-		if (OauthType.APPLE.equals(member.getOauthType())) {
-			log.info("revoke apple user");
-			oauthClient.revoke(member.getRefreshToken());
-		}
-		memberWriter.remove(member);
+		memberWriter.withdraw(member);
 	}
 }

--- a/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
@@ -22,13 +22,12 @@ public class AppleAuthController {
 
 	@PostMapping("/v1/oauth/apple")
 	public ResponseEntity<Void> test(
-		@RequestParam("code") String code,
 		@RequestParam("id_token") String id_token,
 		@RequestParam(name = "user", required = false) String user
 	) throws IOException {
 		// TODO: 이전에 가입한 적 있지만 DB를 갈아엎어서 user가 들어오지 않는 경우 save에 실패한다.
 		if (user != null) {
-			appleAuthService.save(code, id_token, user);
+			appleAuthService.save(id_token, user);
 		}
 		String accessToken = appleAuthService.getAccessToken(id_token);
 		HttpHeaders httpHeaders = new HttpHeaders();

--- a/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/controller/AppleAuthController.java
@@ -29,7 +29,7 @@ public class AppleAuthController {
 		if (user != null) {
 			appleAuthService.save(id_token, user);
 		}
-		String accessToken = appleAuthService.getAccessToken(id_token);
+		String accessToken = appleAuthService.login(id_token);
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.add("Location", "https://dev.mouda.site/oauth/apple?token=" + accessToken);
 		return new ResponseEntity<>(httpHeaders, HttpStatus.FOUND);

--- a/backend/src/main/java/mouda/backend/auth/presentation/controller/AuthController.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/controller/AuthController.java
@@ -17,7 +17,6 @@ import mouda.backend.auth.presentation.business.CommonAuthService;
 import mouda.backend.auth.presentation.controller.swagger.AuthSwagger;
 import mouda.backend.auth.presentation.request.GoogleOauthRequest;
 import mouda.backend.auth.presentation.request.OauthRequest;
-import mouda.backend.auth.presentation.response.KakaoLoginResponse;
 import mouda.backend.auth.presentation.response.LoginResponse;
 import mouda.backend.common.config.argumentresolver.LoginMember;
 import mouda.backend.common.response.RestResponse;
@@ -35,8 +34,8 @@ public class AuthController implements AuthSwagger {
 
 	@Override
 	@PostMapping("/kakao/oauth")
-	public ResponseEntity<RestResponse<KakaoLoginResponse>> loginKakaoOauth(@RequestBody OauthRequest oauthRequest) {
-		KakaoLoginResponse response = kakaoAuthService.oauthLogin(oauthRequest);
+	public ResponseEntity<RestResponse<LoginResponse>> loginKakaoOauth(@RequestBody OauthRequest oauthRequest) {
+		LoginResponse response = kakaoAuthService.oauthLogin(oauthRequest);
 
 		return ResponseEntity.ok().body(new RestResponse<>(response));
 	}

--- a/backend/src/main/java/mouda/backend/auth/presentation/controller/swagger/AuthSwagger.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/controller/swagger/AuthSwagger.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import mouda.backend.auth.presentation.request.GoogleOauthRequest;
 import mouda.backend.auth.presentation.request.OauthRequest;
-import mouda.backend.auth.presentation.response.KakaoLoginResponse;
 import mouda.backend.auth.presentation.response.LoginResponse;
 import mouda.backend.common.config.argumentresolver.LoginMember;
 import mouda.backend.common.response.RestResponse;
@@ -20,7 +19,7 @@ public interface AuthSwagger {
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그인 성공!"),
 	})
-	ResponseEntity<RestResponse<KakaoLoginResponse>> loginKakaoOauth(@RequestBody OauthRequest oauthRequest);
+	ResponseEntity<RestResponse<LoginResponse>> loginKakaoOauth(@RequestBody OauthRequest oauthRequest);
 
 	@Operation(summary = "테스트 용 로그인(안나)", description = "테스트 용 가짜 사용자로 로그인한다(accessToken 발급).")
 	@ApiResponses({

--- a/backend/src/main/java/mouda/backend/auth/presentation/response/KakaoLoginResponse.java
+++ b/backend/src/main/java/mouda/backend/auth/presentation/response/KakaoLoginResponse.java
@@ -1,7 +1,6 @@
 package mouda.backend.auth.presentation.response;
 
 public record KakaoLoginResponse(
-	Long memberId,
 	String accessToken
 ) {
 }

--- a/backend/src/main/java/mouda/backend/member/domain/LoginDetail.java
+++ b/backend/src/main/java/mouda/backend/member/domain/LoginDetail.java
@@ -16,20 +16,12 @@ public class LoginDetail {
 
 	private String socialLoginId;
 
-	private String refreshToken;
-
 	protected LoginDetail() {
 	}
 
 	public LoginDetail(OauthType oauthType, String socialLoginId) {
 		this.oauthType = oauthType;
 		this.socialLoginId = socialLoginId;
-	}
-
-	public LoginDetail(OauthType oauthType, String socialLoginId, String refreshToken) {
-		this.oauthType = oauthType;
-		this.socialLoginId = socialLoginId;
-		this.refreshToken = refreshToken;
 	}
 
 	@Override

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -64,7 +64,7 @@ public class Member {
 		return MemberStatus.DELETED.equals(this.memberStatus);
 	}
 
-	public void resignup() {
+	public void reSignup() {
 		this.memberStatus = MemberStatus.ACTIVE;
 	}
 

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -60,6 +60,14 @@ public class Member {
 		this.memberStatus = MemberStatus.DELETED;
 	}
 
+	public boolean isDeleted() {
+		return MemberStatus.DELETED.equals(this.memberStatus);
+	}
+
+	public void resignup() {
+		this.memberStatus = MemberStatus.ACTIVE;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,11 +31,15 @@ public class Member {
 	@Embedded
 	private LoginDetail loginDetail;
 
+	@Enumerated(EnumType.STRING)
+	private MemberStatus memberStatus;
+
 	@Builder
 	public Member(String name, LoginDetail loginDetail) {
 		this.loginDetail = loginDetail;
 		validateName(name);
 		this.name = name;
+		this.memberStatus = MemberStatus.ACTIVE;
 	}
 
 	private void validateName(String name) {
@@ -50,8 +56,8 @@ public class Member {
 		return loginDetail.getOauthType();
 	}
 
-	public String getRefreshToken() {
-		return loginDetail.getRefreshToken();
+	public void withdraw() {
+		this.memberStatus = MemberStatus.DELETED;
 	}
 
 	@Override

--- a/backend/src/main/java/mouda/backend/member/domain/MemberStatus.java
+++ b/backend/src/main/java/mouda/backend/member/domain/MemberStatus.java
@@ -1,0 +1,7 @@
+package mouda.backend.member.domain;
+
+public enum MemberStatus {
+
+	ACTIVE,
+	DELETED
+}

--- a/backend/src/main/java/mouda/backend/member/implement/MemberWriter.java
+++ b/backend/src/main/java/mouda/backend/member/implement/MemberWriter.java
@@ -25,7 +25,8 @@ public class MemberWriter {
 		memberRepository.updateName(memberId, name);
 	}
 
-	public void remove(Member member) {
-		memberRepository.delete(member);
+	public void withdraw(Member member) {
+		member.withdraw();
+		memberRepository.save(member);
 	}
 }

--- a/backend/src/test/java/mouda/backend/auth/business/GoogleAuthServiceTest.java
+++ b/backend/src/test/java/mouda/backend/auth/business/GoogleAuthServiceTest.java
@@ -1,0 +1,55 @@
+package mouda.backend.auth.business;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import mouda.backend.auth.implement.GoogleOauthManager;
+import mouda.backend.auth.presentation.request.GoogleOauthRequest;
+import mouda.backend.auth.presentation.response.LoginResponse;
+import mouda.backend.common.fixture.MemberFixture;
+import mouda.backend.member.domain.Member;
+import mouda.backend.member.domain.MemberStatus;
+import mouda.backend.member.infrastructure.MemberRepository;
+
+@SpringBootTest
+class GoogleAuthServiceTest {
+
+	@Autowired
+	private GoogleAuthService googleAuthService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@MockBean
+	private GoogleOauthManager googleOauthManager;
+
+	@DisplayName("회원 탈퇴한 사용자가 재가입하는 경우 상태 정보를 변경한다.")
+	@Test
+	void processSocialLoginWhoDeletedBefore() {
+		// given
+		Member anna = MemberFixture.getAnna();
+		anna.withdraw();
+		memberRepository.save(anna);
+
+		when(googleOauthManager.getMemberName(anyString())).thenReturn("anna");
+		when(googleOauthManager.getSocialLoginId(anyString())).thenReturn(anna.getSocialLoginId());
+
+		// when
+		LoginResponse loginResponse = googleAuthService.oauthLogin(new GoogleOauthRequest(null, "IdToken"));
+
+		// then
+		assertThat(loginResponse.accessToken()).isNotNull();
+		Optional<Member> member = memberRepository.findByLoginDetail_SocialLoginId("1234");
+		assertThat(member.isPresent()).isTrue();
+		assertThat(member.get().getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+	}
+}

--- a/backend/src/test/java/mouda/backend/auth/implement/LoginManagerTest.java
+++ b/backend/src/test/java/mouda/backend/auth/implement/LoginManagerTest.java
@@ -39,7 +39,6 @@ class LoginManagerTest {
 
 		// then
 		assertThat(loginProcessResult.accessToken()).isNotNull();
-		assertThat(loginProcessResult.memberId()).isEqualTo(member.getId());
 		Optional<Member> foundMember = memberRepository.findByLoginDetail_SocialLoginId(member.getSocialLoginId());
 		assertThat(foundMember.isPresent()).isTrue();
 		assertThat(foundMember.get()).isEqualTo(member);

--- a/backend/src/test/java/mouda/backend/auth/implement/MemberWriterTest.java
+++ b/backend/src/test/java/mouda/backend/auth/implement/MemberWriterTest.java
@@ -2,6 +2,8 @@ package mouda.backend.auth.implement;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +38,7 @@ class MemberWriterTest {
 		assertThat(memberRepository.findAll()).hasSize(1);
 	}
 
-	@DisplayName("멤버를 삭제한다.")
+	@DisplayName("회원을 삭제 시 상태가 변경된다.")
 	@Test
 	void withdraw() {
 		// given
@@ -47,6 +49,8 @@ class MemberWriterTest {
 		memberWriter.withdraw(tebah);
 
 		// then
-		assertThat(memberRepository.findAll()).hasSize(0);
+		List<Member> members = memberRepository.findAll();
+		assertThat(members).hasSize(1);
+		assertThat(members.get(0)).isEqualTo(tebah);
 	}
 }

--- a/backend/src/test/java/mouda/backend/auth/implement/MemberWriterTest.java
+++ b/backend/src/test/java/mouda/backend/auth/implement/MemberWriterTest.java
@@ -38,13 +38,13 @@ class MemberWriterTest {
 
 	@DisplayName("멤버를 삭제한다.")
 	@Test
-	void remove() {
+	void withdraw() {
 		// given
 		Member tebah = MemberFixture.getTebah();
 		memberWriter.append(tebah);
 
 		// when
-		memberWriter.remove(tebah);
+		memberWriter.withdraw(tebah);
 
 		// then
 		assertThat(memberRepository.findAll()).hasSize(0);


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

## 이슈 ID는 무엇인가요?

- 회원 탈퇴 시 논리 삭제 구현
- 재가입 시 탈퇴 회원임을 확인하고 변경하는 로직 구현

- #685 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

- 회원 탈퇴를 논리 삭제로 구현한 이유

회원 탈퇴를 물리 삭제로 구현하고자 하였습니다. 
하지만 애플 측에서 우리 서비스에게 사용자의 이름을 최초 1회 제공하고 있기 때문에, 회원 탈퇴 후 재가입 시 이름이 없는 회원이 생길 수 있다는 문제가 있었습니다.  우리 서비스에서 애플 사용자를 완전히 제거하는 API를 제공하고 있지 않아서, 논리 삭제를 통해 해당 문제를 해결하고자 하였습니다.

- 재가입 시 로직

재가입 시 가입 이력이 있다면 상태 변경을 통해 가입 처리합니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->

미구현 로직
- 탈퇴한 회원의 access token을 사용해 진입하는 것을 막습니다. 이 부분은 intercetor에서, argument resolver에서 구현할 수 있으나 방식의 논의가 필요해 이슈를 남겨둡니다.
-  회원 탈퇴 시 관련 데이터를 모두 삭제. 데이터를 삭제하는 것은 급한 요구사항이 아니며 재가입하더라도 데이터가 남아있는 정책이 필요할 것 같아 논의가 필요합니다.