### PR TITLE
알림 재전송시 발생하는 오류 해결 및 로깅 개선

### DIFF
--- a/backend/src/main/java/mouda/backend/notification/domain/FcmToken.java
+++ b/backend/src/main/java/mouda/backend/notification/domain/FcmToken.java
@@ -1,0 +1,23 @@
+package mouda.backend.notification.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@Builder
+public class FcmToken {
+
+	private final long memberId;
+	private final long tokenId;
+	private final String token;
+
+	@Override
+	public String toString() {
+		return "FcmToken{" +
+			"memberId=" + memberId +
+			", tokenId=" + tokenId +
+			'}';
+	}
+}

--- a/backend/src/main/java/mouda/backend/notification/implement/fcm/FcmNotificationSender.java
+++ b/backend/src/main/java/mouda/backend/notification/implement/fcm/FcmNotificationSender.java
@@ -1,9 +1,7 @@
 package mouda.backend.notification.implement.fcm;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Component;
 
@@ -13,29 +11,27 @@ import com.google.api.core.ApiFutures;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
-import com.google.firebase.messaging.SendResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mouda.backend.notification.domain.CommonNotification;
+import mouda.backend.notification.domain.FcmToken;
 import mouda.backend.notification.domain.Recipient;
 import mouda.backend.notification.implement.NotificationSender;
 import mouda.backend.notification.implement.fcm.token.FcmTokenFinder;
-import mouda.backend.notification.implement.fcm.token.FcmTokenWriter;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class FcmNotificationSender implements NotificationSender {
 
+	private static final int MAX_ATTEMPT = 3;
 	private static final int THREAD_POOL_SIZE_FOR_CALLBACK = 5;
 
 	private final FcmMessageFactory fcmMessageFactory;
-	private final FcmTokenFinder fcmTokenFinder;
 	private final FcmResponseHandler fcmResponseHandler;
-	private final FcmTokenWriter fcmTokenWriter;
+	private final FcmTokenFinder fcmTokenFinder;
 
 	@Override
 	public void sendNotification(CommonNotification notification, List<Recipient> recipients) {
@@ -48,64 +44,44 @@ public class FcmNotificationSender implements NotificationSender {
 			return;
 		}
 
+		int attempt = 1;
 		fcmMessageFactory.createMessage(notification, tokens)
-			.forEach(multicastMessage -> sendMulticastMessage(notification, multicastMessage, tokens));
+			.forEach(multicastMessage -> sendMulticastMessage(notification, multicastMessage, tokens, attempt));
 	}
 
-	private void sendMulticastMessage(CommonNotification notification, MulticastMessage message,
-		List<String> initialTokens) {
+	private void sendMulticastMessage(
+		CommonNotification notification, MulticastMessage message, List<String> initialTokens, int attempt
+	) {
+		if (attempt > MAX_ATTEMPT) {
+			List<FcmToken> tokens = fcmTokenFinder.readAllByTokensIn(initialTokens);
+			log.info("Max attempt reached for title: {}, body: {}, failed: {}", notification.getTitle(),
+				notification.getBody(), tokens);
+			return;
+		}
+
 		ApiFuture<BatchResponse> future = FirebaseMessaging.getInstance().sendEachForMulticastAsync(message);
 		ApiFutures.addCallback(future, new ApiFutureCallback<>() {
 			@Override
 			public void onFailure(Throwable t) {
 				if (t instanceof FirebaseMessagingException exception) {
-					log.error("Error Sending Message. error code: {}, messaging error code: {}, error message: {}",
-						exception.getErrorCode(), exception.getMessagingErrorCode(), exception.getMessage());
+					log.error(
+						"Error Sending Message. title: {}, body: {}, error code: {}, messaging error code: {}, error message: {}",
+						notification.getTitle(), notification.getBody(), exception.getMessagingErrorCode(),
+						exception.getMessagingErrorCode(), exception.getMessage()
+					);
 				}
+				sendMulticastMessage(notification, message, initialTokens, attempt + 1);
 			}
 
 			@Override
 			public void onSuccess(BatchResponse result) {
 				if (result.getFailureCount() == 0) {
-					log.info("All messages were sent successfully. message: {}", notification.getTitle());
+					log.info("All messages were sent successfully. title: {}, body: {}", notification.getTitle(),
+						notification.getBody());
 					return;
 				}
-				List<String> registeredTokens = checkUnregisteredTokensAndDelete(result, initialTokens);
-				if (registeredTokens.isEmpty()) {
-					return;
-				}
-				fcmResponseHandler.handleBatchResponse(result, notification, registeredTokens);
+				fcmResponseHandler.handleBatchResponse(result, notification, initialTokens);
 			}
 		}, Executors.newFixedThreadPool(THREAD_POOL_SIZE_FOR_CALLBACK));
-	}
-
-	/**
-	 * @param batchResponse 처음 알림을 전송했을 때의 응답
-	 * @param tokens        처음 알림을 전송했을 때 사용한 토큰
-	 * @return 등록되지 않은(FCM 에서 Unregistered 를 응답한) 토큰을 제거한 뒤, 나머지의 토큰을 반환
-	 */
-	private List<String> checkUnregisteredTokensAndDelete(BatchResponse batchResponse, List<String> tokens) {
-		tokens = new ArrayList<>(tokens);
-		List<SendResponse> responses = batchResponse.getResponses();
-		List<String> unregisteredTokens = IntStream.range(0, responses.size())
-			.filter(i -> isUnregistered(responses.get(i)))
-			.mapToObj(tokens::get)
-			.toList();
-
-		if (!unregisteredTokens.isEmpty()) {
-			log.info("{} of {} tokens are unregistered. Deleting them..", unregisteredTokens.size(), tokens.size());
-			fcmTokenWriter.deleteAll(unregisteredTokens);
-			tokens.removeAll(unregisteredTokens);
-		}
-
-		return tokens;
-	}
-
-	private boolean isUnregistered(SendResponse response) {
-		if (response.isSuccessful()) {
-			return false;
-		}
-		MessagingErrorCode messagingErrorCode = response.getException().getMessagingErrorCode();
-		return messagingErrorCode == MessagingErrorCode.UNREGISTERED;
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/implement/fcm/FcmResponseHandler.java
+++ b/backend/src/main/java/mouda/backend/notification/implement/fcm/FcmResponseHandler.java
@@ -17,6 +17,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mouda.backend.notification.domain.CommonNotification;
 import mouda.backend.notification.domain.FcmFailedResponse;
+import mouda.backend.notification.domain.FcmToken;
+import mouda.backend.notification.implement.fcm.token.FcmTokenFinder;
+import mouda.backend.notification.implement.fcm.token.FcmTokenWriter;
 
 @Component
 @RequiredArgsConstructor
@@ -29,67 +32,99 @@ public class FcmResponseHandler {
 
 	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(5);
 	private final FcmMessageFactory fcmMessageFactory;
+	private final FcmTokenFinder fcmTokenFinder;
+	private final FcmTokenWriter fcmTokenWriter;
 
 	@PreDestroy
 	public void destroy() {
 		scheduler.shutdown();
 	}
 
-	public void handleBatchResponse(BatchResponse batchResponse, CommonNotification notification,
-		List<String> initialTokens) {
-		FcmFailedResponse failedResponse = FcmFailedResponse.from(batchResponse, initialTokens);
+	public void handleBatchResponse(
+		BatchResponse batchResponse, CommonNotification notification, List<String> initialTokens
+	) {
+		List<FcmToken> tokens = fcmTokenFinder.readAllByTokensIn(initialTokens);
+		FcmFailedResponse failedResponse = FcmFailedResponse.from(batchResponse, tokens);
 
 		int attempt = 1;
 		retryAsync(notification, failedResponse, attempt, BACKOFF_DELAY_FOR_SECONDS);
 	}
 
-	private void retryAsync(CommonNotification notification, FcmFailedResponse failedResponse, int attempt,
-		int backoffDelayForSeconds) {
+	private void retryAsync(
+		CommonNotification notification, FcmFailedResponse failedResponse, int attempt, int backoffDelayForSeconds
+	) {
 		if (attempt > MAX_ATTEMPT) {
-			log.info("Max attempt reached for notification: {}. failed: {}", notification.getBody(),
-				failedResponse.getFinallyFailedTokens());
+			log.info("Max attempt reached for title: {}, body: {}, failed: {}", notification.getTitle(),
+				notification.getBody(), failedResponse.getFinallyFailedTokens());
+			removeAllUnregisteredTokens(failedResponse.getFailedWith404Tokens());
 			return;
 		}
-
 		if (failedResponse.hasNoRetryableTokens()) {
-			log.info("No Retryable tokens for notification: {}. failed: {}.", notification.getBody(),
-				failedResponse.getNonRetryableFailedTokens());
+			log.info("No Retryable tokens for title: {}, body: {}, failed: {}.", notification.getTitle(),
+				notification.getBody(), failedResponse.getNonRetryableFailedTokens());
+			removeAllUnregisteredTokens(failedResponse.getFailedWith404Tokens());
 			return;
 		}
-
-		if (failedResponse.hasFailedWith429Tokens()) {
-			int retryAfterSeconds = failedResponse.getRetryAfterSeconds();
-			scheduler.schedule(() -> {
-				log.info("Retrying 429 for notification: {}. Thread: {}", notification.getTitle(),
-					Thread.currentThread().getName());
-				FcmFailedResponse retryResponse = retry(failedResponse, notification,
-					failedResponse.getFailedWith429Tokens());
-				retryAsync(notification, retryResponse, attempt + 1, backoffDelayForSeconds * BACKOFF_MULTIPLIER);
-			}, retryAfterSeconds, TimeUnit.SECONDS);
-		}
-
-		if (failedResponse.hasFailedWith5xxTokens()) {
-			scheduler.schedule(() -> {
-				log.info("Retrying 5xx for notification: {}. Thread: {}", notification.getTitle(),
-					Thread.currentThread().getName());
-				FcmFailedResponse retryResponse = retry(failedResponse, notification,
-					failedResponse.getFailedWith5xxTokens());
-				retryAsync(notification, retryResponse, attempt + 1, backoffDelayForSeconds * BACKOFF_MULTIPLIER);
-			}, backoffDelayForSeconds, TimeUnit.SECONDS);
-		}
+		retryUsingRetryAfter(notification, failedResponse, attempt, backoffDelayForSeconds);
+		retryUsingBackoff(notification, failedResponse, attempt, backoffDelayForSeconds);
 	}
 
-	private FcmFailedResponse retry(FcmFailedResponse origin, CommonNotification notification,
-		List<String> retryTokens) {
-		log.info("Retrying for notification: {}. failed: {}, Thread: {}", notification.getTitle(), retryTokens,
-			Thread.currentThread().getName());
-		MulticastMessage message = fcmMessageFactory.createMessage(notification, retryTokens).get(0);
+	private void removeAllUnregisteredTokens(List<FcmToken> failedWith404Tokens) {
+		if (failedWith404Tokens.isEmpty()) {
+			return;
+		}
+		log.info("Removing all unregistered tokens: {}", failedWith404Tokens);
+		List<String> tokens = failedWith404Tokens.stream().map(FcmToken::getToken).toList();
+
+		fcmTokenWriter.deleteAll(tokens);
+	}
+
+	private void retryUsingRetryAfter(
+		CommonNotification notification, FcmFailedResponse failedResponse, int attempt, int backOffDelayForSeconds
+	) {
+		List<FcmToken> failedWith429Tokens = failedResponse.getFailedWith429Tokens();
+		if (failedWith429Tokens.isEmpty()) {
+			return;
+		}
+
+		int retryAfterSeconds = failedResponse.getRetryAfterSeconds();
+		scheduler.schedule(() -> {
+			log.info("Retrying 429 retry for title: {}, body: {}, tokens: {}.", notification.getTitle(),
+				notification.getBody(), failedWith429Tokens);
+
+			FcmFailedResponse retryResponse = sendNotification(failedResponse, notification, failedWith429Tokens);
+			retryAsync(notification, retryResponse, attempt + 1, backOffDelayForSeconds * BACKOFF_MULTIPLIER);
+		}, retryAfterSeconds, TimeUnit.SECONDS);
+	}
+
+	private void retryUsingBackoff(
+		CommonNotification notification, FcmFailedResponse failedResponse, int attempt, int backoffDelayForSeconds
+	) {
+		List<FcmToken> failedWith5xxTokens = failedResponse.getFailedWith5xxTokens();
+		if (failedWith5xxTokens.isEmpty()) {
+			return;
+		}
+
+		scheduler.schedule(() -> {
+			log.info("Retrying 5xx for title: {}, body: {}, tokens: {}.", notification.getTitle(),
+				notification.getBody(), failedWith5xxTokens);
+			FcmFailedResponse retryResponse = sendNotification(failedResponse, notification, failedWith5xxTokens);
+			retryAsync(notification, retryResponse, attempt + 1, backoffDelayForSeconds * BACKOFF_MULTIPLIER);
+		}, backoffDelayForSeconds, TimeUnit.SECONDS);
+	}
+
+	private FcmFailedResponse sendNotification(
+		FcmFailedResponse origin, CommonNotification notification, List<FcmToken> retryTokens
+	) {
+		List<String> tokens = retryTokens.stream().map(FcmToken::getToken).toList();
+		MulticastMessage message = fcmMessageFactory.createMessage(notification, tokens).get(0);
 
 		try {
 			BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
 			return FcmFailedResponse.from(response, retryTokens);
 		} catch (FirebaseMessagingException e) {
-			log.error("Error Sending Message. error message: {}", e.getMessage());
+			log.error("Error Sending Message while retrying.. title: {}, body: {}, error message: {}",
+				notification.getTitle(), notification.getBody(), e.getMessage());
 			return origin;
 		}
 	}

--- a/backend/src/main/java/mouda/backend/notification/implement/fcm/token/FcmTokenFinder.java
+++ b/backend/src/main/java/mouda/backend/notification/implement/fcm/token/FcmTokenFinder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import mouda.backend.notification.domain.FcmToken;
 import mouda.backend.notification.domain.Recipient;
 import mouda.backend.notification.infrastructure.entity.FcmTokenEntity;
 import mouda.backend.notification.infrastructure.repository.FcmTokenRepository;
@@ -25,5 +26,15 @@ public class FcmTokenFinder {
 			fcmTokens.addAll(tokens);
 		}
 		return fcmTokens;
+	}
+
+	public List<FcmToken> readAllByTokensIn(List<String> tokens) {
+		return fcmTokenRepository.findAllByTokenIn(tokens).stream()
+			.map(entity -> FcmToken.builder()
+				.memberId(entity.getMemberId())
+				.token(entity.getToken())
+				.build()
+			)
+			.toList();
 	}
 }

--- a/backend/src/main/java/mouda/backend/notification/infrastructure/repository/FcmTokenRepository.java
+++ b/backend/src/main/java/mouda/backend/notification/infrastructure/repository/FcmTokenRepository.java
@@ -14,4 +14,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmTokenEntity, Long> 
 	Optional<FcmTokenEntity> findByToken(String token);
 
 	void deleteAllByTokenIn(List<String> unregisteredTokens);
+
+	List<FcmTokenEntity> findAllByTokenIn(List<String> tokens);
 }

--- a/backend/src/main/java/mouda/backend/notification/util/FcmRetryAfterExtractor.java
+++ b/backend/src/main/java/mouda/backend/notification/util/FcmRetryAfterExtractor.java
@@ -1,0 +1,39 @@
+package mouda.backend.notification.util;
+
+import java.util.List;
+
+import com.google.firebase.IncomingHttpResponse;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.SendResponse;
+
+public class FcmRetryAfterExtractor {
+
+	private static final int DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+	public static int getRetryAfterSeconds(BatchResponse batchResponse) {
+		List<SendResponse> responses = batchResponse.getResponses();
+		return responses.stream()
+			.filter(FcmRetryAfterExtractor::isFailedWith429)
+			.map(FcmRetryAfterExtractor::parseRetryAfterSeconds)
+			.findAny()
+			.orElse(DEFAULT_RETRY_AFTER_SECONDS);
+	}
+
+	private static boolean isFailedWith429(SendResponse response) {
+		return response.getException().getMessagingErrorCode() == MessagingErrorCode.QUOTA_EXCEEDED;
+	}
+
+	private static int parseRetryAfterSeconds(SendResponse response) {
+		FirebaseMessagingException exception = response.getException();
+		IncomingHttpResponse httpResponse = exception.getHttpResponse();
+		Object retryAfterHeader = httpResponse.getHeaders().get("Retry-After");
+
+		try {
+			return Integer.parseInt(retryAfterHeader.toString());
+		} catch (Exception e) {
+			return DEFAULT_RETRY_AFTER_SECONDS;
+		}
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

QA에서 확인한 알림 재전송 과정에서 발생하는 IndexOutOfBoundsException 해결 및 로깅 개선

## 이슈 ID는 무엇인가요?

- #694 

## 설명

### 오류 해결
기존의 알림 전송 과정을 대략적으로 보면 다음과 같습니다.
1. 메시지를 전송한다. 
2. 실패하는 응답 중 404(UNREGISTERED)에 해당되는 토큰을 제거한다.
3. 제거되고 남은 토큰과 FCM 응답 객체를 FcmResponseHandler에 넣어서 재전송 처리를 시도한다.

이 과정에서 **제거되고 남은 토큰과 FCM 응답 객체에 있는 응답의 수가 일치하지 않아 발생**하는 예외를 해결했습니다. 
등록되지 않은 토큰을 제거한 뒤 재시도하는게 아닌, 일단 재시도 하고 재시도 과정이 끝나면 한 번에 지우도록 수정했어요.

### 로깅 개선
FCM에서 예외가 발생하는 상황은 지금까지는 거의 없었던 것 같아요. 
정말 운이 좋게도 지난 QA에서 알림 예외가 발생해서 로그를 천천히 확인해봤는데 에러 로그를 조금 더 친절하게 작성할 수 있겠다는 생각이 들어 수정했어요.

**[기존]**
알림 제목  + 실패한 토큰

**[수정]**
알림 제목 + 알림 내용(바디) + 실패한 토큰의 memberId와 tokenId

문자열 토큰이 길이가 꽤나 길어서 로그에서 가독성도 안좋고, 누구의 토큰인지 확인할 때 DB에 일일이 복붙해서 찾아야 하는 번거로움이 있는 것 같아 ID값을 로깅하도록 수정했습니다.

이 과정에서 DB 조회가 한번 더 들어가긴 하지만, FCM 예외는 일반적으로 잘 발생하지 않아 성능에 큰 영향은 주지 않을 것이라 판단했습니다.

## 질문 혹은 공유 사항 (Optional)

알림 재전송 쪽은 아마 이해하기 쉽지 않을 것이라 생각합니다.. 그래서 내용은 최대한 풀어 썼는데, 코드상에서 궁금한게 있으면 질문 남겨주세요.
