### PR TITLE
베팅 채팅방에서 채팅 전송 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
@@ -32,14 +32,8 @@ public class BetFinder {
 	public Bet find(long darakbangId, long betEntityId) {
 		BetEntity betEntity = betRepository.findByIdAndDarakbangId(betEntityId, darakbangId)
 			.orElseThrow(() -> new BetException(HttpStatus.NOT_FOUND, BetErrorMessage.BET_NOT_FOUND));
-		List<Participant> participants = participantFinder.findAllByBetEntity(betEntity);
 
-		return Bet.builder()
-			.betDetails(betEntity.toBetDetails())
-			.moimerId(betEntity.getMoimerId())
-			.participants(participants)
-			.loserId(betEntity.getLoserDarakbangMemberId())
-			.build();
+		return createBet(betEntity);
 	}
 
 	public List<Bet> findAllByDarakbangId(long darakbangId) {


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
bet 관련 알림을 보내는 중 bet에 있는 darakbangId 정보 누락으로 인해 채팅 전송 트랜젝션이 롤백되는 문제 수정

## 이슈 ID는 무엇인가요?

- #731 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->
- BetFinder 의 find 메서드에서 Bet 생성시 darakbangId 가 누락된 문제 수정

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
