### PR TITLE
애플 로그인 시 이미 가입한 유저라면 회원가입 실패 기능 구현

### DIFF
--- a/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/AppleAuthService.java
@@ -1,5 +1,7 @@
 package mouda.backend.auth.business;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +34,10 @@ public class AppleAuthService {
 	}
 
 	private LoginResponse handleNewUser(String user, String identifier) {
+		Optional<Member> member = memberFinder.getByIdentifier(identifier);
+		if (member.isPresent()) {
+			return new LoginResponse(accessTokenProvider.provide(member.get()), member.get().isConverted());
+		}
 		Member joinedMember = join(identifier, user);
 		return new LoginResponse(accessTokenProvider.provide(joinedMember), joinedMember.isConverted());
 	}

--- a/backend/src/main/java/mouda/backend/auth/implement/AppleUserInfoProvider.java
+++ b/backend/src/main/java/mouda/backend/auth/implement/AppleUserInfoProvider.java
@@ -32,7 +32,7 @@ public class AppleUserInfoProvider {
 			JsonNode node = objectMapper.readTree(user);
 			String firstName = node.path("name").path("firstName").asText();
 			String lastName = node.path("name").path("lastName").asText();
-			return firstName + lastName;
+			return lastName + firstName;
 		} catch (JsonProcessingException exception) {
 			throw new AuthException(HttpStatus.BAD_REQUEST, AuthErrorMessage.APPLE_USER_BAD_REQUEST);
 		}

--- a/backend/src/main/java/mouda/backend/member/implement/MemberFinder.java
+++ b/backend/src/main/java/mouda/backend/member/implement/MemberFinder.java
@@ -1,5 +1,7 @@
 package mouda.backend.member.implement;
 
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,10 @@ import mouda.backend.member.infrastructure.MemberRepository;
 public class MemberFinder {
 
 	private final MemberRepository memberRepository;
+
+	public Optional<Member> getByIdentifier(String identifier) {
+		return memberRepository.findByLoginDetail_Identifier(identifier);
+	}
 
 	public Member findActiveOrDeletedByIdentifier(String identifier) {
 		return memberRepository.findActiveOrDeletedByIdentifier(identifier)

--- a/backend/src/main/java/mouda/backend/member/infrastructure/MemberRepository.java
+++ b/backend/src/main/java/mouda/backend/member/infrastructure/MemberRepository.java
@@ -13,6 +13,8 @@ import mouda.backend.member.domain.OauthType;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+	Optional<Member> findByLoginDetail_Identifier(String identifier);
+
 	@Query("""
 			SELECT m FROM Member m
 			WHERE m.loginDetail.identifier = :identifier AND (m.memberStatus = 'ACTIVE' OR m.memberStatus = 'DELETED')

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ oauth:
     redirect-uri: https://dev.mouda.site/oauth/google
   apple:
     redirect-uri: https://api.dev.mouda.site/v1/auth/apple
-    redirection: https://dev.mouda.site/oauth/apple?token=
+    redirection: https://dev.mouda.site/oauth/apple?token=%s&isConverted=%s
 
 aws:
   region:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -35,6 +35,7 @@ oauth:
     redirect-uri: https://mouda.site/oauth/google
   apple:
     redirect-uri: https://mouda.site/v1/auth/apple
+    redirection: https://test.mouda.site/oauth/apple?token=%s&isConverted=%s
 
 aws:
   region:

--- a/backend/src/test/java/mouda/backend/auth/business/AppleAuthServiceTest.java
+++ b/backend/src/test/java/mouda/backend/auth/business/AppleAuthServiceTest.java
@@ -86,4 +86,22 @@ class AppleAuthServiceTest {
 		assertThat(member.isPresent()).isTrue();
 		assertThat(member.get().getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
 	}
+
+	@DisplayName("최초 애플 로그인인 경우에 DB에 이미 로그인 이력이 있다면 바로 로그인한다.")
+	@Test
+	void loginIfExistsMember() {
+		// given
+		Member anna = MemberFixture.getAnna(identifier);
+		memberRepository.save(anna);
+
+		// when
+		LoginResponse response = appleAuthService.login("idToken", "user");
+
+		// then
+		assertThat(response.accessToken()).isNotNull();
+		Optional<Member> member = memberRepository.findByLoginDetail_Identifier(identifier);
+		assertThat(member.isPresent()).isTrue();
+		assertThat(member.get().getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.get().getIdentifier()).isEqualTo(identifier);
+	}
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

![image](https://github.com/user-attachments/assets/0556df79-70f0-44c4-bdd3-2aa87fa51879)

위와 같이 임의로 기기에서 사용자 정보를 지우고 가입하는 경우, 검증 없이 같은 데이터가 여러 개 쌓이는 이슈가 있다.
또한, 사용자 이름이 호연조 처럼 이름과 성이 바뀌어진다.

## 이슈 ID는 무엇인가요?

- #738 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

사용자 성과 이름 위치를 바꾸기
회원가입 시 이미 ACTIVE 상태인 같은 identifier가 있는 경우 예외처리한다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
