### PR TITLE
회원 객체의 상태를 직접 변경하여 더티체킹 하도록 수정

### DIFF
--- a/backend/src/main/java/mouda/backend/auth/business/KakaoAuthService.java
+++ b/backend/src/main/java/mouda/backend/auth/business/KakaoAuthService.java
@@ -22,7 +22,7 @@ public class KakaoAuthService {
 	public void convert(Member alternation, KakaoConvertRequest kakaoConvertRequest) {
 		String identifier = userInfoProvider.getIdentifier(kakaoConvertRequest.code());
 		Member kakao = memberFinder.findActiveOrDeletedByIdentifier(identifier);
-		memberWriter.updateLoginDetail(kakao.getId(), alternation.getLoginDetail());
+		memberWriter.updateLoginDetail(kakao, alternation.getLoginDetail());
 		kakao.convert();
 		memberWriter.deprecate(alternation);
 	}

--- a/backend/src/main/java/mouda/backend/member/domain/Member.java
+++ b/backend/src/main/java/mouda/backend/member/domain/Member.java
@@ -81,6 +81,10 @@ public class Member {
 		this.memberStatus = MemberStatus.DEPRECATED;
 	}
 
+	public void updateLoginDetail(LoginDetail loginDetail) {
+		this.loginDetail = loginDetail;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)

--- a/backend/src/main/java/mouda/backend/member/implement/MemberWriter.java
+++ b/backend/src/main/java/mouda/backend/member/implement/MemberWriter.java
@@ -17,9 +17,9 @@ public class MemberWriter {
 		return memberRepository.save(member);
 	}
 
-	public void updateLoginDetail(long memberId, LoginDetail loginDetail) {
-		memberRepository.updateLoginDetail(memberId, loginDetail.getOauthType(),
-			loginDetail.getIdentifier());
+	public void updateLoginDetail(Member member, LoginDetail loginDetail) {
+		member.updateLoginDetail(loginDetail);
+		memberRepository.save(member);
 	}
 
 	public void updateName(long memberId, String name) {

--- a/backend/src/test/java/mouda/backend/auth/business/KakaoAuthServiceTest.java
+++ b/backend/src/test/java/mouda/backend/auth/business/KakaoAuthServiceTest.java
@@ -49,8 +49,13 @@ class KakaoAuthServiceTest {
 
 		// then
 		Optional<Member> kakaoMember = memberRepository.findActiveOrDeletedByIdentifier(kakaoIdentifier);
-		assertThat(kakaoMember.isPresent()).isTrue();
-		assertThat(kakaoMember.get().getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(kakaoMember.isEmpty()).isTrue();
+
+		Optional<Member> convertedMember = memberRepository.findActiveOrDeletedByIdentifier(googleIdentifier);
+		assertThat(convertedMember.isPresent()).isTrue();
+		assertThat(convertedMember.get().getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(convertedMember.get().isConverted()).isTrue();
+
 		Optional<Member> googleMember = memberRepository.findDeprecatedByIdentifier(googleIdentifier);
 		assertThat(googleMember.isPresent()).isTrue();
 		assertThat(googleMember.get().getMemberStatus()).isEqualTo(MemberStatus.DEPRECATED);


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
사용자 전환 중 더티 체킹으로 인한 변경 사항이 덮어씌워지는 현상 해결

## 이슈 ID는 무엇인가요?

- #741 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

(1) 카카오 회원의 로그인 정보를 변경한다 => 쿼리로 작성
(2) 카카오 회원의 isConverted를 변경한다. => 쓰기 지연

두 과정에 의해 첫 번째 과정이 두 번째 과정에 의해 덮어씌워지게 되면서,
기존 카카오 회원의 identifier와 oauth_type이 변경되지 않는 문제가 있다.

사용자 전환을 위한 로그인 정보 변경 시 쿼리가 아닌 JPA의 쓰기 지연을 사용해서, 객체 자체의 값이 변경되도록 한다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
