### PR TITLE
중복 모임 채팅방 생성 버그 픽스

### DIFF
--- a/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
+++ b/backend/src/main/java/mouda/backend/chat/exception/ChatErrorMessage.java
@@ -11,8 +11,9 @@ public enum ChatErrorMessage {
 	BET_DARAKBANG_MEMBER_NOT_FOUND("참여하지 않은 안내면진다입니다."),
 	INVALID_CHATROOM_TYPE("잘못된 채팅 방 타입입니다."),
 	UNAUTHORIZED("권한이 없습니다."),
-
 	INVALID_DATE_TIME_FORMAT("날짜와 시간 형식이 올바르지 않습니다."),
+	CHATROOM_ALREADY_EXISTS("이미 존재하는 채팅방입니다."), // 새로 추가된 메시지
+
 	;
 
 	private final String message;

--- a/backend/src/main/java/mouda/backend/chat/implement/ChatRoomValidator.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/ChatRoomValidator.java
@@ -1,0 +1,23 @@
+package mouda.backend.chat.implement;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import mouda.backend.chat.domain.ChatRoomType;
+import mouda.backend.chat.exception.ChatErrorMessage;
+import mouda.backend.chat.exception.ChatException;
+import mouda.backend.chat.infrastructure.ChatRoomRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomValidator {
+
+	private final ChatRoomRepository chatRoomRepository;
+
+	public void validateAlreadyExists(long targetId, ChatRoomType chatRoomType) {
+		if (chatRoomRepository.existsByTargetIdAndType(targetId, chatRoomType)) {
+			throw new ChatException(HttpStatus.BAD_REQUEST, ChatErrorMessage.CHATROOM_ALREADY_EXISTS);
+		}
+	}
+}

--- a/backend/src/main/java/mouda/backend/chat/implement/ChatRoomWriter.java
+++ b/backend/src/main/java/mouda/backend/chat/implement/ChatRoomWriter.java
@@ -12,8 +12,11 @@ import mouda.backend.chat.infrastructure.ChatRoomRepository;
 public class ChatRoomWriter {
 
 	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRoomValidator chatRoomValidator;
 
 	public long append(long targetId, long darakbangId, ChatRoomType chatRoomType) {
+		chatRoomValidator.validateAlreadyExists(targetId, chatRoomType);
+
 		ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
 			.targetId(targetId)
 			.darakbangId(darakbangId)

--- a/backend/src/main/java/mouda/backend/chat/infrastructure/ChatRoomRepository.java
+++ b/backend/src/main/java/mouda/backend/chat/infrastructure/ChatRoomRepository.java
@@ -11,4 +11,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
 	Optional<ChatRoomEntity> findByIdAndDarakbangId(Long chatRoomId, long darakbangId);
 
 	Optional<ChatRoomEntity> findByTargetIdAndType(long targetId, ChatRoomType chatRoomType);
+
+	boolean existsByTargetIdAndType(long targetId, ChatRoomType chatRoomType);
 }

--- a/backend/src/test/java/mouda/backend/chat/implement/ChatRoomValidatorTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/ChatRoomValidatorTest.java
@@ -1,0 +1,67 @@
+package mouda.backend.chat.implement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import mouda.backend.bet.entity.BetEntity;
+import mouda.backend.bet.infrastructure.BetRepository;
+import mouda.backend.chat.domain.ChatRoomType;
+import mouda.backend.chat.entity.ChatRoomEntity;
+import mouda.backend.chat.exception.ChatException;
+import mouda.backend.chat.infrastructure.ChatRoomRepository;
+import mouda.backend.common.fixture.BetEntityFixture;
+import mouda.backend.common.fixture.ChatRoomEntityFixture;
+import mouda.backend.common.fixture.DarakbangSetUp;
+import mouda.backend.common.fixture.MoimFixture;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.infrastructure.MoimRepository;
+
+@SpringBootTest
+class ChatRoomValidatorTest extends DarakbangSetUp {
+
+	@Autowired
+	ChatRoomValidator chatRoomValidator;
+
+	@Autowired
+	MoimRepository moimRepository;
+
+	@Autowired
+	BetRepository betRepository;
+
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+
+	@DisplayName("이미 존재하는 채팅방인지 검증한다. - ChatRoomType.MOIM")
+	@Test
+	void existedChatRoom_typeMoim() {
+		// given
+		Moim moim = MoimFixture.getCoffeeMoim(darakbang.getId());
+		Moim savedMoim = moimRepository.save(moim);
+
+		ChatRoomEntity chatRoomEntityOfMoim = ChatRoomEntityFixture.getChatRoomEntityOfMoim(savedMoim.getId(), darakbang.getId());
+		chatRoomRepository.save(chatRoomEntityOfMoim);
+
+		// when & then
+		assertThatThrownBy(() -> chatRoomValidator.validateAlreadyExists(savedMoim.getId(), ChatRoomType.MOIM))
+			.isInstanceOf(ChatException.class);
+	}
+
+	@DisplayName("이미 존재하는 채팅방인지 검증한다. - ChatRoomType.BET")
+	@Test
+	void existedChatRoom_typeBet() {
+		// given
+		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbang.getId(), darakbangAnna.getId());
+		BetEntity savedBet = betRepository.save(betEntity);
+
+		ChatRoomEntity chatRoomEntityOfBet = ChatRoomEntityFixture.getChatRoomEntityOfBet(savedBet.getId(), darakbang.getId());
+		chatRoomRepository.save(chatRoomEntityOfBet);
+
+		// when & then
+		assertThatThrownBy(() -> chatRoomValidator.validateAlreadyExists(savedBet.getId(), ChatRoomType.BET))
+			.isInstanceOf(ChatException.class);
+	}
+}

--- a/backend/src/test/java/mouda/backend/chat/implement/ChatRoomWriterTest.java
+++ b/backend/src/test/java/mouda/backend/chat/implement/ChatRoomWriterTest.java
@@ -1,0 +1,79 @@
+package mouda.backend.chat.implement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import mouda.backend.bet.entity.BetEntity;
+import mouda.backend.bet.infrastructure.BetRepository;
+import mouda.backend.chat.domain.ChatRoomType;
+import mouda.backend.chat.entity.ChatRoomEntity;
+import mouda.backend.chat.exception.ChatException;
+import mouda.backend.chat.infrastructure.ChatRoomRepository;
+import mouda.backend.common.fixture.BetEntityFixture;
+import mouda.backend.common.fixture.DarakbangSetUp;
+import mouda.backend.common.fixture.MoimFixture;
+import mouda.backend.moim.domain.Moim;
+import mouda.backend.moim.infrastructure.MoimRepository;
+
+class ChatRoomWriterTest extends DarakbangSetUp {
+
+	@Autowired
+	ChatRoomWriter chatRoomWriter;
+
+	@Autowired
+	MoimRepository moimRepository;
+
+	@Autowired
+	BetRepository betRepository;
+
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+
+	@DisplayName("새로운 채팅방을 생성한다.")
+	@Test
+	void append() {
+		// given
+		Moim moim = MoimFixture.getCoffeeMoim(darakbang.getId());
+		Moim savedMoim = moimRepository.save(moim);
+
+		// when
+		chatRoomWriter.append(savedMoim.getId(), darakbang.getId(), ChatRoomType.MOIM);
+
+		//then
+		Optional<ChatRoomEntity> chatRoomEntity = chatRoomRepository.findByTargetIdAndType(savedMoim.getId(), ChatRoomType.MOIM);
+		assertThat(chatRoomEntity.isPresent()).isTrue();
+		assertThat(chatRoomEntity.get().getTargetId()).isEqualTo(savedMoim.getId());
+		assertThat(chatRoomEntity.get().getType()).isEqualTo(ChatRoomType.MOIM);
+	}
+
+	@DisplayName("이미 존재하는 모임 채팅방일 땐 예외를 발생한다.")
+	@Test
+	void append_alreadyExistedMoimChatRoom() {
+		// given
+		Moim moim = MoimFixture.getCoffeeMoim(darakbang.getId());
+		Moim savedMoim = moimRepository.save(moim);
+		chatRoomWriter.append(savedMoim.getId(), darakbang.getId(), ChatRoomType.MOIM);
+
+		// when & then
+		assertThatThrownBy(() -> chatRoomWriter.append(savedMoim.getId(), darakbang.getId(), ChatRoomType.MOIM))
+			.isInstanceOf(ChatException.class);
+	}
+
+	@DisplayName("이미 존재하는 배팅 채팅방일 땐 예외를 발생한다.")
+	@Test
+	void append_alreadyExistedBetChatRoom() {
+		// given
+		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbang.getId(), darakbangAnna.getId());
+		BetEntity savedBet = betRepository.save(betEntity);
+		chatRoomWriter.append(savedBet.getId(), darakbang.getId(), ChatRoomType.BET);
+
+		// when & then
+		assertThatThrownBy(() -> chatRoomWriter.append(savedBet.getId(), darakbang.getId(), ChatRoomType.BET))
+			.isInstanceOf(ChatException.class);
+	}
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->
새로운 채팅방을 생성할 때 targetId 와 ChatRoomType 을 기준으로 이미 존재하는 채팅방인지 검증하는 로직 누락으로 이미 존재하는 채팅방이 있음에도 중복 생성이 되는 문제 해결

## 이슈 ID는 무엇인가요?

- #751

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->
### 기존 ChatRoomWriter.append
```java
public long append(long targetId, long darakbangId, ChatRoomType chatRoomType) {
ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
	.targetId(targetId)
	.darakbangId(darakbangId)
	.type(chatRoomType)
	.build();
return chatRoomRepository.save(chatRoomEntity).getId();
}
```

### 변경된 ChatRoomWriter
```java
private final ChatRoomValidator chatRoomValidator;

public long append(long targetId, long darakbangId, ChatRoomType chatRoomType) {
chatRoomValidator.validateAlreadyExists(targetId, chatRoomType);

ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
	.targetId(targetId)
	.darakbangId(darakbangId)
	.type(chatRoomType)
	.build();
return chatRoomRepository.save(chatRoomEntity).getId();
}
```
### 검증 코드의 위치를 서비스가 아닌 구현레이어에 둔 이유
채팅방이 이미 존재하는지 검증하는 로직은 항상 생성하는 로직 이전에 이루어져야 한다고 판단하였습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
