### PR TITLE
모임 목록, 룰렛 목록 플러스 버튼에 의해 아이템 가려지는 문제 해결

### DIFF
--- a/frontend/src/components/PlusButton/PlusButton.style.ts
+++ b/frontend/src/components/PlusButton/PlusButton.style.ts
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 
 export const plusButton = css`
+  pointer-events: auto;
+
   width: 68px;
   height: 68px;
   padding: 0;

--- a/frontend/src/layouts/components/FixedCreationButtonWrapper/FixedCreationButtonWrapper.style.ts
+++ b/frontend/src/layouts/components/FixedCreationButtonWrapper/FixedCreationButtonWrapper.style.ts
@@ -2,6 +2,8 @@ import { DISPLAY_MAX_WIDTH, NAVIGATION_BAR_HEIGHT } from '@_constants/styles';
 import { css } from '@emotion/react';
 
 export const fixedWrapperStyle = css`
+  pointer-events: none;
+
   position: fixed;
   bottom: 18px;
 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

모임 목록, 룰렛 목록 플러스 버튼에 의해 아이템 가려지는 문제 해결

## 이슈 ID는 무엇인가요?

- #771

## 설명

css의 `event-pointer`로 해결 -> 이걸로 div 영역이 pointer 이벤트를 안먹게 할 수 있네요!
